### PR TITLE
build0020: Bundle db4o, upload WoT JAR from Travis CI to Freenet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "db4o-7.4"]
+	path = db4o-7.4
+	url = https://github.com/xor-freenet/db4o-7.4.git

--- a/.travis.upload-jar-to-freenet.sh
+++ b/.travis.upload-jar-to-freenet.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+FILENAME="WebOfTrust-$(git describe)-built-on-$TRAVIS_JDK_VERSION.jar"
+URI="CHK@/$FILENAME"
+
+echo "Installing pyFreenet3..."
+pip3 install -U --user --egg pyFreenet3
+
+# FIXME: As of 2018-05-03 fcpupload's "--spawn" parameter doesn't work,
+# see https://bugs.freenetproject.org/view.php?id=7018 - so we start our
+# own node.
+# Once that is fixed don't start a node here - do so by reverting the
+# commit which added this FIXME.
+
+cd "$TRAVIS_BUILD_DIR"/../fred
+echo "Configuring node..."
+
+# FIXME: Use fred's official URL once there is one
+wget https://github.com/ArneBab/lib-pyFreenet-staging/releases/download/spawn-ext-data/seednodes.fref
+
+cat << EOF > freenet.ini
+node.updater.enabled=false
+node.clientCacheType=ram
+node.storeType=ram
+fproxy.hasCompletedWizard=true
+security-levels.physicalThreatLevel=LOW
+security-levels.networkThreatLevel=LOW
+node.opennet.enabled=true
+node.outputBandwidthLimit=1048576
+node.inputBandwidthLimit=-1
+node.opennet.maxOpennetPeers=65
+node.load.threadLimit=1000
+logger.priority=NONE
+End
+EOF
+
+echo "Starting node..."
+java -Xmx512M -classpath 'build/output/*' -Djna.nosys=true freenet.node.NodeStarter &
+cd "$TRAVIS_BUILD_DIR"
+
+echo "Giving node 60s to boot..."
+sleep 60s
+
+echo "Uploading WoT JAR to $URI..."
+
+# Echo something every minute to prevent Travis from killing the job
+# after 10 minutes of silence.
+(
+	minutes=0
+	while sleep 1m ; do
+		echo Minutes passed: $((++minutes))
+	done
+) &
+
+# TODO: As of 2018-05-30 fcpupload's "--timeout" doesn't work, using coreutils' timeout, try again later
+# TODO: As of 2018-05-30 fcpupload's "--compress" also doesn't work.
+if ! time timeout 30m fcpupload --wait "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+	echo "Uploading WebOfTrust.jar to Freenet failed!" >&2
+	
+	# The commented out lines are for debugging fcpupload's "--spawn".
+	#
+	# echo "Uploading WebOfTrust.jar to Freenet failed! Dumping wrapper.log, wrapper.conf and listing node dir..." >&2
+	# echo "wrapper.log:" >&2
+	# cat "$HOME/.local/share/babcom-spawn-9486/wrapper.log" >&2
+	# echo "wrapper.conf:" >&2
+	# cat "$HOME/.local/share/babcom-spawn-9486/wrapper.conf" >&2
+	# echo "Node dir:" >&2
+	# ls -alR "$HOME/.local/share/babcom-spawn-9486/" >&2
+	
+	exit 1
+fi
+
+# Can't use "kill $(jobs -p)" as that fails if a job exits in between
+jobs -p | xargs --no-run-if-empty kill || true
+
+if ! wait ; then
+	echo "Node exit code indicates error!" >&2
+	exit 1
+fi
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 
 # We need Ubuntu 14.04 due to very new JUnit API which WoT needs
-sudo: required
 dist: trusty
+# Disabling sudo routes the build to a Docker container instead of a VM
+# which speeds up the build.
+sudo: false
 
 addons:
   apt:
@@ -11,25 +13,57 @@ addons:
     - ant-optional
     - junit4
     - libhamcrest-java
+    # For .travis.upload-jar-to-freenet.sh
+    - python3-pip
   # TODO: Code quality: Remove this workaround for https://github.com/travis-ci/travis-ci/issues/5227
+  hosts:
+    - freenet-plugin-WebOfTrust
   hostname: freenet-plugin-WebOfTrust
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f  $HOME/.gradle/caches/jars-2/jars-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
   apt: true
   directories:
   - $TRAVIS_BUILD_DIR/../fred/
+  - $HOME/.m2
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/
 
 before_install:
   - cd "$TRAVIS_BUILD_DIR"/..
-  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
-  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
-  - cd fred/lib ; rm -f bcprov.jar ; ln -s bcprov-jdk15on-154.jar bcprov.jar ; cd ../..
-  - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
+  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred ; else cd fred ; git pull ; cd .. ; fi
+  - cd fred
+  - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
+  # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
+  - if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then rm ./gradlew && ln -s "$(which gradle)" ./gradlew ; fi
+  # TODO: freenet.jar won't contain class Version if we don't run the
+  # clean task in a separate execution of Gradle. Why?
+  - ./gradlew clean
+  # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
+  # needs - to build/output/
+  - ./gradlew jar copyRuntimeLibs -x test
   - cd "$TRAVIS_BUILD_DIR"
+  # Print the checksums of the WoT dependencies - for debugging
+  - sha256sum ../fred/build/output/*
 
 script: ant
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
+  # openjdk9: As of 2018-05-12 isn't available on Travis yet.
+  # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+
+deploy:
+  provider: script
+  # Prevent Travis from deleting the JAR before we can deploy it (wtf?)
+  skip_cleanup: true
+  script: ./.travis.upload-jar-to-freenet.sh
+  on:
+    all_branches: true

--- a/build.xml
+++ b/build.xml
@@ -2,15 +2,47 @@
 <!-- ant build file for WoT -->
 
 <project name="WoT" default="dist" basedir="." xmlns:if="ant:if" xmlns:unless="ant:unless">
+	<!-- ======================================================================================= -->
+	<!-- Configuration                                                                           -->
+	<!-- ======================================================================================= -->
+		
+	<!-- You can use these file to override the below properties. -->
 	<property file="override.properties"/>
-
-	<property name="freenet-cvs-snapshot.location" location="../fred/dist/freenet.jar"/>
-	<property name="freenet-ext.location" location="../fred/lib/freenet/freenet-ext.jar"/>
-	<property name="bcprov.location" location="../fred/lib/bcprov.jar"/>
+	<!-- Dependencies. These are the most important to configure!                               -->
+	<!--                                                                                        -->
+	<!-- Freenet build01481 compiled with "./gradlew jar copyRuntimeLibs" will copy the         -->
+	<!-- freenet.jar and its dependencies to this directory:                                    -->
+	<property name="freenet.lib.new.location"   location="../fred/build/output/"/>
+	<!-- Older Freenet builds will use these places for the JARs, some of which have to be      -->
+	<!-- downloaded manually:                                                                   -->
+	<property name="freenet.lib.old.location.1" location="../fred/lib/bcprov.jar"/>
+	<property name="freenet.lib.old.location.2" location="../fred/lib/jna-platform.jar"/>
+	<property name="freenet.lib.old.location.3" location="../fred/lib/jna.jar"/>
+	<property name="freenet.lib.old.location.4" location="../fred/lib/freenet/freenet-ext.jar"/>
+	<property name="freenet.lib.old.location.5" location="../fred/dist/freenet.jar"/>
+	<!-- Unit test dependencies                                                                 -->
+	<property name="junit.location" value="/usr/share/java/junit4.jar"/>
+	<property name="hamcrest.location" value="/usr/share/java/hamcrest-core.jar"/>
+	<!-- Optional, only needed if using "ant -Dtest.coverage=true"                              -->
+	<property name="cobertura.location" value="/usr/share/java/cobertura.jar"/>
+	<!-- Minimum Java version which fred officially requires
+	   = Maximum version which WoT's code can use features of. -->
+	<property name="source-version" value="7"/>
+	<property name="target-version" value="7"/>
+	<!-- To allow you to restart your debug node after recompiling without manually reloading
+	     the WoT plugin you can specifiy this property to point to the node's WebOfTrust.jar.
+	     The Ant builder will delete it automatically as part of the "clean" target. -->
 	<property name="debug-node-wot-plugin.location" location="../fred/plugins/WebOfTrust.jar"/>
+	
+	<!-- ======================================================================================= -->
+	<!-- Configuration which you should probably leave as is!                                    -->
+	<!-- ======================================================================================= -->
+	
+	<!-- Git submodule directory of the db4o source code. Will be compiled automatically! -->
+	<property name="db4o-submodule.location" location="db4o-7.4"/>
+	<!-- JAR which the Ant builder of db4o produces. -->
+	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
 	<property name="svn.revision" value="@custom@"/>
-	<property name="source-version" value="1.7"/>
-	<property name="target-version" value="1.7"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
 	<property name="build-test-jar" location="${build-test}/WebOfTrust-with-unit-tests.jar"/>
@@ -18,9 +50,6 @@
 	<property name="dist" location="dist/"/>
 	<property name="src" location="src/"/>
 	<property name="javadoc" location="javadoc/"/>
-	<property name="junit.location" value="/usr/share/java/junit4.jar"/>
-	<property name="hamcrest.location" value="/usr/share/java/hamcrest-core.jar"/>
-	<property name="cobertura.location" value="/usr/share/java/cobertura.jar"/>
 	<property name="version.src" value="plugins/WebOfTrust/Version.java" />
 	<property name="version.build" value="plugins/WebOfTrust/Version.class" />
 
@@ -30,14 +59,40 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
+	<!-- Libraries whose classes are to be bundled in our own JAR. -->
+	<path id="submodules.path">
+		<pathelement location="${db4o.location}"/>
+	</path>
+	<!-- Libraries which we get from fred. -->
 	<path id="lib.path">
-		<pathelement location="${bcprov.location}"/>
-		<pathelement location="${freenet-ext.location}"/>
-		<pathelement location="${freenet-cvs-snapshot.location}"/>
+		<!-- Use filesets instead of <pathelement> to:
+		     - allow using wildcards when including freenet.lib.new.location so we don't need to
+		       synchronize the list of JARs which fred needs with what this build file includes.
+		     - for the old JAR locations ensure the print-libs task won't print files which don't
+		       exist as that is what he wildcard usage dictates for thew new location already. -->
+		
+		<fileset dir="${freenet.lib.new.location}" erroronmissingdir="no" casesensitive="no">
+			<include name="**/*.jar"/>
+		</fileset>
+		<fileset file="${freenet.lib.old.location.1}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.2}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.3}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.4}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.5}" erroronmissingdir="no"/>
 	</path>
 
 	<path id="cobertura.path">
 		<pathelement location="${cobertura.location}"/>
+	</path>
+	
+	<!-- For print-libs task: All runtime dependencies of WoT plus the build-time dependencies.
+	     Uses <fileset> instead of <pathelement> so it only contains only those which exist as that
+	     is what lib.path does already. -->
+	<path id="lib.external.all.path">
+		<path refid="lib.path"/>
+		<fileset file="${junit.location}" />
+		<fileset file="${hamcrest.location}"/>
+		<fileset file="${cobertura.location}"/>
 	</path>
 
 	<presetdef name="javac">
@@ -73,20 +128,53 @@
 		</and>
 	</condition>
 
+	<target name="get-submodules" description="Downloads the git submodules required by WoT">
+		<echo>Downloading db4o git submodule if it doesn't exist already...</echo>
+		<exec executable="git">
+			<arg line="submodule update --init"/>
+		</exec>
+	</target>
+
+	<target name="db4o" depends="get-submodules" description="Compiles the database submodule">
+		<echo>Compiling db4o submodule...</echo>
+		<ant dir="${db4o-submodule.location}" inheritAll="false" useNativeBasedir="true">
+			<property name="javac.source.version" value="${source-version}"/>
+			<property name="javac.target.version" value="${target-version}"/>
+		</ant>
+	</target>
+
+	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
+		<echo>Cleaning db4o submodule...</echo>
+		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
+			useNativeBasedir="true"/>
+	</target>
+
+
+	<target name="print-libs">
+		<echo>External dependencies on classpath follow, but ONLY those which did exist.</echo>
+		<echo>(This cannot tell which JARs are missing because that would require ant-contrib</echo>
+		<echo>and I don't want to require Freenet release managers to install it. Sorry.)</echo>
+		<echo></echo>
+		<echo>If compiling fails due to missing classes please:</echo>
+		<echo>- ensure fred was built with "./gradlew jar copyRuntimeLibs" to make it copy</echo>
+		<echo>  its dependencies' JARs to "build/output/".</echo>
+		<echo>- compare the found JARs against the configuration at top of build.xml to find</echo>
+		<echo>  out which JARs are missing.</echo>
+		<echo></echo>
+		<pathconvert refid="lib.external.all.path" pathsep="${line.separator}" property="all.path.printable"/>
+		<echo>${all.path.printable}</echo>
+	</target>
+
 	<target name="mkdir">
 		<mkdir dir="${build}"/>
 		<mkdir dir="${build-test}"/>
 		<mkdir dir="${build-test}/test"/>
 		<mkdir dir="${build-test-coverage}"/>
 		<mkdir dir="${dist}"/>
-		<echo message="Using ${freenet-cvs-snapshot.location} as freenet-cvs-snapshot.jar"/>
-		<echo message="Using ${freenet-ext.location} as freenet-ext.jar"/>
-		<echo message="Using ${bcprov.location} as bcprov.jar"/>
-		<echo message="Using ${cobertura.location} as cobertura.jar"/>
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="mkdir" >
+	<target name="compile" depends="print-libs, db4o, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -101,6 +189,7 @@
 		<!-- Force compile of Version.java in case compile of ${src} didn't trigger it -->
 		<javac srcdir="${build}" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}">
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 			</classpath>
 			<include name="${version.src}"/>
@@ -109,6 +198,7 @@
 		<!-- FIXME: remove the debug and replace with optimize -->
 		<javac srcdir="src/" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}" encoding="UTF-8">
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 			</classpath>
 			<include name="**/*.java"/>
@@ -135,6 +225,7 @@
 				source="${source-version}" target="${target-version}" >
 			
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 				<pathelement path="${build}"/>
 				<pathelement location="${junit.location}"/>
@@ -178,6 +269,9 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
+			<zipfileset>
+				<path refid="submodules.path"/>
+			</zipfileset>
 		</jar>
 	</target>
 
@@ -227,6 +321,7 @@
 						unless="test.unreliable" />
 					<exclude name="**/TickerDelayedBackgroundJobTest.class"
 						unless="test.unreliable" />
+					<exclude name="com/db4o/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -265,6 +360,7 @@
 					     JUnit would then complain that those classes do not contain a public
 					     constructor. -->
 					<exclude name="**/*$*.class"/>
+					<exclude name="com/db4o/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -287,27 +383,34 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
+			<zipfileset>
+				<path refid="submodules.path"/>
+			</zipfileset>
 		</jar>
 	</target>
 
 	<!-- ================================================== -->
 	<target name="javadoc" description="generate javadocs">
 		<delete dir="${javadoc}"/>
-		<javadoc classpathref="lib.path" destdir="${javadoc}" author="true" version="true" use="true" private="true">
+		<path id="javadoc.classpath">
+			<path refid="submodules.path"/>
+			<path refid="lib.path"/>
+		</path>
+		<javadoc classpathref="javadoc.classpath" destdir="${javadoc}" author="true" version="true" use="true" private="true">
 			<fileset dir="src/" defaultexcludes="yes">
 				<include name="**/*.java"/>
 			</fileset>
-			<link href="http://docs.oracle.com/javase/6/docs/api/"/>
+			<link href="http://docs.oracle.com/javase/${source-version}/docs/api/"/>
 			<link href="http://freenetproject.org/javadocs/"/>
 		</javadoc>
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-db4o" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>
 		<delete dir="${dist}"/>
-		<delete file="${debug-node-WebOfTrust-plugin.location}"/>
+		<delete file="${debug-node-wot-plugin.location}"/>
 	</target>
 </project>

--- a/developer-documentation/changelogs/build0020.txt
+++ b/developer-documentation/changelogs/build0020.txt
@@ -1,0 +1,217 @@
+Web of Trust Version 0.4.5 build0020
+------------------------------------------------------------------------
+
+SUMMARY (detailed changelog is below)
+
+This is an intermediate maintenance build which caters mostly to
+developers, testers and paranoid users.
+Especially Freenet core developers shall benefit from its two primary
+goals:
+
+1) It prepares WoT for the removal of the library freenet-ext.jar and
+   its contained db4o library from Freenet.
+   It does so by bundling db4o inside WoT's JAR and making WoT
+   independent from the naming of the JARs which Freenet depends on.
+
+2) The cloud service Travis CI, which was previously only used for
+   running WoT unit tests, now automatically uploads the resulting
+   WoT binary to Freenet after it has compiled and tested it.
+
+Users and testers can also benefit from aspect 2 by using it to have an
+independent service validate that the published WoT binary matches the
+source code, see the below full changelog at issue 0007018.
+
+The bundling of db4o should in theory work on existing Freenet
+installations where db4o is both contained in Freenet and in WoT - but
+it would be nice to have some confirmation from testers that this does
+indeed work on various operating systems and Java versions.
+So feedback on whether it works on your installation would be
+appreciated.
+
+TESTING
+
+Make sure to backup the WebOfTrust directory (located in the directory
+Freenet is installed to) before you use this!
+
+Easy high level testing:
+- Check the Community / Statistics page for unusual stuff. E.g.:
+  - Data loss, e.g. decreasing count of own identities, non-own
+    identities or trust values as compared to your database before
+    installation of the testing version.
+  - High count of "Failed files" at the Identity file queue / Identity
+    file processor section.
+  - No significant progress in average downloaded / queued / processed
+    identity XML files  even after a day of uptime.
+
+Tedious low level testing:
+- Check "freenet-latest.log" for ERRORs of plugins.WebOfTrust.*
+  You can filter for this by configuring logging as:
+  - Set "Minimum priority to log messages at" to "NONE".
+  - Set "Detailed priority thresholds" to "plugins.WebOfTrust:ERROR".
+    Now any logging except WoT errors is disabled.
+  Besides you should probably increase "Log rotation interval" to
+  "48HOUR" (yes, no S in HOUR), the default is very low, 1 hour IIRC.
+  Before you report anything from the log file make VERY sure to review
+  it for private data! It might even contain the secret insert URIs of
+  your identities!
+
+DOWNLOAD
+
+Until it has been shipped with a Freenet release this build is available
+using "WebOfTrust Testing Versions" at "Configuration / Plugins" of a
+standard Freenet node.
+You need to unload the regular WoT first!
+
+CHANGELOG - prefixed with the bugtracker issue number
+
+- 0007018: [Code quality] Travis CI: Upload WebOfTrust.jar to Freenet
+           using pyFreenet (xor)
+
+  Travis CI is a cloud service which allows us to automatically compile
+  WoT from the source code and run the unit tests.
+
+  WoT's Travis script has been amended to spawn a Freenet node and
+  upload the compiled WoT binary to Freenet.
+  This can be a great stress reduction for release managers as the trust
+  they need to put into the security of their machine is greatly reduced
+  if they can choose to build the binaries elsewhere.
+  The overall security of that might be a bit better because Travis is a
+  large, widely used service and thereby they have more resources at
+  hand to ensure a secure infrastructure.
+  Further users can use it as a third-party verification that we didn't
+  put secret code into the binaries before we uploaded them (see below).
+
+  To obtain the Freenet URI of an uploaded WoT JAR search the raw Travis
+  job log for "CHK@". Jobs are at:
+    https://travis-ci.org/xor-freenet/plugin-WebOfTrust/builds
+    https://travis-ci.org/freenet/plugin-WebOfTrust/builds
+  For every build there are usually different jobs for various Java
+  versions. For WoT testing releases I will be using the CHK as compiled
+  by OpenJDK in the version which is the minimal requirement of Freenet
+  at time of the release. For this WoT release that is OpenJDK 7.
+
+  The JAR will only be uploaded if compiling and testing did succeed,
+  otherwise there will be no CHK@ in the output.
+
+  If Freenet release managers choose to use Travis CI for compiling then
+  the CHK@ URI which they put into fred will match what Travis CI has
+  published in the build job for the git tag build0020 (= commit
+  "Version 0.4.5 build0020") of this release.
+  As the CHK contains a strong hash of the file it being identical
+  proves that it indeed serves the same file as Travis CI produced.
+  Once testing of this build is finished and it has been released as
+  part of a regular Freenet release you can check the CHK@ in the
+  following file of the fred repository:
+    src/freenet/pluginmanager/OfficialPlugins.java
+  which is hosted at
+    https://git.io/vhcsV
+
+  While this release is still in testing verification works differently
+  because the testing URI is an USK:
+  Download the Travis CHK and the testing USK (listed in the above
+  file) and compare a checksum of the resulting file, e.g. with the
+  sha256sum command.
+
+- 0006737: [Code quality] Prepare for fred's removal of freenet-ext.jar
+           and db4o
+
+  Freenet build01482 is scheduled to split up freenet-ext.jar into
+  multiple JARs, and during this procedure remove db4o from the set of
+  JARs which Freenet ships.
+
+  To prepare for that, the following has been done:
+
+  - the WoT build script has been amended to bundle db4o in WoT's own
+    JAR. To achieve that a db4o-7.4 repository has been extracted from
+    the Freenet "contrib" repository.
+    WoT's build script has been amended to automatically clone that git
+    repository and compile db4o locally.
+    To ensure the least possible effort is required by Freenet release
+    managers in validating that these db4o binaries match what had been
+    deployed as part of freenet-ext previously, the following steps were
+    taken:
+      - the db4o-7.4 repository is pulled by the build script using a
+        "git submodule" which ensures that the specific commit which is
+        pulled is hardcoded into the WoT repository and can only be
+        changed manually by whoever has push access to the WoT
+        repository hosted by Freenet.
+        This means that I can host the db4o-7.4 repository on my own
+        GitHub account (xor-freenet) WITHOUT being able to change what
+        people get when they pull WoT from Freenet's GitHub.
+        In turn Freenet does not have to host a clone of the db4o
+        repository on their own.
+      - the db4o-7.4 repository was extracted from Freenet's contrib
+        repository, not from the original db4o SVN. This allows Freenet
+        release managers to simply use:
+          $ git verify-tag v29
+          $ gitk v29..HEAD
+        to see what has changed between the deployed freenet-ext and
+        the new db4o-7.4 repository.
+        Keeping the db4o version which WoT uses as close to what it has
+        been using previously is critically important because my test
+        runs have shown that newer db4o versions trigger severe bugs.
+        That is also why the repository is called "db4o-7.4" instead of
+        just "db4o" - to document that WoT currently needs precisely that
+        version.
+        Once I am ready to deal with fixing the bugs triggered by newer
+        versions I will publish the original db4o SVN repository as a
+        git repository called "db4o" and switch WoT to use that. So the
+        db4o commit history is not lost yet :)
+
+  - WoT's build script has been changed to not hardcode any specific
+    filenames of JARs which fred and thereby WoT needs as dependencies.
+    Instead all JARs in the directory
+      ../fred/build/output/
+    are included on the classpath when building WoT. That directory is
+    populated if fred is built with:
+      $ ./gradlew jar copyRuntimeLibs
+    To allow you to test whether the WoT builder finds all JARs a new
+    Ant task was introduced:
+      $ ant print-libs
+    It should show all runtime dependencies of fred (see its Gradle
+    build file), plus "junit4.jar", "hamcrest-core.jar" and
+    optionally "cobertura.jar" if using "ant -Dtest.coverage=true".
+    (The db4o JAR won't be shown as that is not an external dependency,
+    i.e. WoT obtains it automatically, you don't have to provide it.)
+    If compiling fails due to missing classes see the "Configuration"
+    section at top of "build.xml" for the configured locations - all
+    external JARs have been moved to that section.
+
+- 0006929: [Bugs] Travis CI builds fail due to changes at fred (xor)
+
+  The .travis.yml configuration of Travis CI has been fixed to be
+  compatible to the huge changeset of the Freenet core fred which is
+  being developed on fred's next branch.
+  Specifically it was adapted to be compatible with the new Gradle
+  builder of fred which has replaced Ant there - while keeping Ant at
+  WoT so we don't have too much migration efforts going on for now.
+
+  The unit tests of WoT do succeed against the new fred code so
+  hopefully WoT won't delay the release of the fred changes any further
+  than they have already been delayed.
+  This also the first time where the "CI" = continuous integration
+  in Travis CI is really happening to meet its definition:
+  I don't have a Gradle build setup for fred branch next yet so it is of
+  true benefit to be able to test it elsewhere :)
+
+- 0007016: [Bugs] Fix unit test failure on Java 9 (xor)
+
+  Fixes a bug in the unit tests, not in the actual code.
+
+  Symptom was:
+    junit.framework.AssertionFailedError: static final boolean
+    plugins.WebOfTrust.Persistent.$assertionsDisabled expected not same
+
+- 0007017: [Bugs] Fix unit test failure on Java 9 (xor)
+
+  Fixes a bug in the unit tests, not in the actual code.
+
+  Symptom was:
+    testExportIntroduction() would fail due to the Java 9 XML
+    generation code changing the way indentation was produced.
+
+THANKS TO
+
+- ArneBab for being willing to review and deploy WoT.
+- ArneBab for providing pyFreenet which greatly helped in
+  automatically uploading the WoT JAR using Travis CI.

--- a/src/plugins/WebOfTrust/Version.java
+++ b/src/plugins/WebOfTrust/Version.java
@@ -20,7 +20,7 @@ public class Version {
 	 * etc, at a minimum any build inserted into auto-update should have a unique 
 	 * version.
 	 */
-	public static final long version = 19;
+	public static final long version = 20;
 	
 	/** Published as an identity property if you own a seed identity. */
 	public static final long mandatoryVersion = 1;

--- a/src/plugins/WebOfTrust/WebOfTrustInterface.java
+++ b/src/plugins/WebOfTrust/WebOfTrustInterface.java
@@ -41,11 +41,11 @@ public abstract class WebOfTrustInterface {
 	 * the Freenet development team provides a list of seed identities - each of them is one of the developers.
 	 */
 	static final String[] SEED_IDENTITIES = new String[] { 
-		"USK@QeTBVWTwBldfI-lrF~xf0nqFVDdQoSUghT~PvhyJ1NE,OjEywGD063La2H-IihD7iYtZm3rC0BP6UTvvwyF5Zh4,AQACAAE/WebOfTrust/1524", // xor
+		"USK@QeTBVWTwBldfI-lrF~xf0nqFVDdQoSUghT~PvhyJ1NE,OjEywGD063La2H-IihD7iYtZm3rC0BP6UTvvwyF5Zh4,AQACAAE/WebOfTrust/1531", // xor
 		"USK@z9dv7wqsxIBCiFLW7VijMGXD9Gl-EXAqBAwzQ4aq26s,4Uvc~Fjw3i9toGeQuBkDARUV5mF7OTKoAhqOA9LpNdo,AQACAAE/WebOfTrust/5156", // Toad
-		"USK@o2~q8EMoBkCNEgzLUL97hLPdddco9ix1oAnEa~VzZtg,X~vTpL2LSyKvwQoYBx~eleI2RF6QzYJpzuenfcKDKBM,AQACAAE/WebOfTrust/17330", // Bombe
+		"USK@o2~q8EMoBkCNEgzLUL97hLPdddco9ix1oAnEa~VzZtg,X~vTpL2LSyKvwQoYBx~eleI2RF6QzYJpzuenfcKDKBM,AQACAAE/WebOfTrust/19619", // Bombe
 		"USK@D3MrAR-AVMqKJRjXnpKW2guW9z1mw5GZ9BB15mYVkVc,xgddjFHx2S~5U6PeFkwqO5V~1gZngFLoM-xaoMKSBI8,AQACAAE/WebOfTrust/8231", // zidel
-		"USK@nmTkFmn0Akz1-G9iIN2w6lsQEAfWkpQw3ckOxtwMh2Q,Du9GQxGDj0Nax4zN9-ANTPetx-GxOoWaRf6Gq6Nbh1o,AQACAAE/WebOfTrust/9141", // operhiem1
+		"USK@nmTkFmn0Akz1-G9iIN2w6lsQEAfWkpQw3ckOxtwMh2Q,Du9GQxGDj0Nax4zN9-ANTPetx-GxOoWaRf6Gq6Nbh1o,AQACAAE/WebOfTrust/11558", // operhiem1
 	};
 	
 	abstract public List<Identity> getAllIdentities();

--- a/test/plugins/WebOfTrust/XMLTransformerTest.java
+++ b/test/plugins/WebOfTrust/XMLTransformerTest.java
@@ -118,7 +118,14 @@ public class XMLTransformerTest extends AbstractJUnit3BaseTest {
 							+ "</IdentityIntroduction>"
 							+ "</" + WebOfTrustInterface.WOT_NAME + ">";
 		
-		assertEquals(expectedXML, os.toString().replaceAll("[\n\r]", ""));
+		String withoutLineBreaks = os.toString().replaceAll("[\n\r]", "");
+		// Workaround for https://bugs.freenetproject.org/view.php?id=7017 while we cannot disable
+		// indentation in the XMLTransformer because it is needed as a workaround for
+		// https://bugs.freenetproject.org/view.php?id=4850 - once that issue is resolved and its
+		// workarounds have been removed please revert the commit which added this.
+		String withoutIndentation = withoutLineBreaks.replaceAll("    ", "");
+		
+		assertEquals(expectedXML, withoutIndentation);
 	}
 
 	public void testImportIntroduction() throws SAXException, IOException, InvalidParameterException {


### PR DESCRIPTION
### Test results

This build has been posted to FMS on ```2018-06-01```.  
There have been no bug reports.

A measurement of yesterday, ```2018-07-10```, shows these numbers of identities using the given builds:
```
[...]
    890 <WebOfTrust Version="19">
     11 <WebOfTrust Version="20">
```

Travis CI ran the unit tests every day since ```2018-06-01``` against fred branch ```next```.  
There was only one failure, and it was unrelated to WoT, it was caused by networking issues at Travis.

### Review instructions

To help you with your preference of not having to read very many commits during review my goal of a few months has been to write code which is more self-explanatory without reading the commit messages :)  
Thus feel free to review this and future PRs as a diff only. If any questions arise add them as a line comment, I'll be happy to answer them and document the source code if necessary.

For this PR I would recommend you to interpret "as a diff" as "as a diff for each branch" to ease review of individual features.
To see a branch diff:
```bash
gitk # Determine MERGE_COMMIT_HASH
git diff MERGE_COMMIT_HASH~1..MERGE_COMMIT_HASH
# or:
git difftool -t TOOL ...
```

Further, to reap something positive from the separation of the core team and me, I would suggest you and me also take a break from potential lengthy discussions and offer you the following idea:  
Review this and upcoming PRs _only_ for bugs and security issues and ignore anything else such as style or design decisions.  
I usually review my commits at least thrice for code quality, so rest assured it is being dealt with.
Btw.: Please submit security issues by encrypted email, not here.

The changelog is in tag ```build0020``` and [here](https://github.com/xor-freenet/plugin-WebOfTrust/blob/9295f39ac70ba10b68f55024f03ce6327d5775ce/developer-documentation/changelogs/build0020.txt), I'd recommend reading it before reviewing.

### Merge instructions

This should be merged **without** a merge-commit as shown below to ensure the ```HEAD``` commit of ```freenet/master``` matches the signed tag ```build0020``` which I've pushed.  
That is necessary for fred to display the version of the WoT plugin properly.

```bash
cd plugin-WebOfTrust
git remote add xor https://github.com/xor-freenet/plugin-WebOfTrust.git
git fetch xor
git checkout master
git diff HEAD..xor/master # Review
git merge --ff-only xor/master
git push --follow-tags origin master # --follow-tags = push the "build0020" tag
git push --follow-tags freenet master
```

### Important post-merge stuff

As the changelog describes in detail this build uses your nice pyFreenet features to make Travis CI upload the JAR to Freenet :)  
Travis CI runs on ```master``` as a cronjob every day on my repository so there's always a fresh CHK available [in the daily build log](https://travis-ci.org/xor-freenet/plugin-WebOfTrust/builds). Thus you should make up your mind on whether you want to use that JAR in Freenet releases, or keep compiling WoT on your own.  
Arguably the weakest link in the security chain of that is probably whether the ```pip3``` stuff which you recommend to obtain pyFreenet is secure.  
To make it robust against that being hacked I can make the next WoT build ```git clone``` a specific commit of pyFreenet instead if you tell me which branch of which repository is equal to what's on ```pip3```.

If you do want to keep compiling WoT on your own, I would be grateful if you could test whether my changes to the Ant builder which make it download the db4o source code do work in your release environment.  
What would especially make me very happy is if you could do this soon-ish so there is enough time left for me to fix issues with it before the next fred release.

Finally, please consider posting the changelog to devl after merging :) It has email-compatible formatting.  
I do get devl mails but have received no instructions about whether I'm allowed to post changelogs.