### PR TITLE
Add scripts to benchmark the unit tests, speed one up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,42 @@ cache:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
 
-before_install:
+# Get/update Freenet Git repository
+install:
   - cd "$TRAVIS_BUILD_DIR"/..
-  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred ; else cd fred ; git pull ; cd .. ; fi
+  - |
+    if [ ! -e fred/.git ] ; then # Must check subdir, main one will be created by Travis cache config.
+      FRED_UPDATED=1
+      git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred
+    fi
   - cd fred
-  - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
-  # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
-  - if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then rm ./gradlew && ln -s "$(which gradle)" ./gradlew ; fi
-  # TODO: freenet.jar won't contain class Version if we don't run the
-  # clean task in a separate execution of Gradle. Why?
-  - ./gradlew clean
-  # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
-  # needs - to build/output/
-  - ./gradlew jar copyRuntimeLibs -x test
+  - git fetch && if [ "$(git rev-parse @)" != "$(git rev-parse @{u})" ] ; then FRED_UPDATED=1 ; git pull ; fi
   - cd "$TRAVIS_BUILD_DIR"
-  # Print the checksums of the WoT dependencies - for debugging
-  - sha256sum ../fred/build/output/*
 
-script: ant
+# Compile Freenet Git repository
+before_script: |
+  if [ "$FRED_UPDATED" = 1 ] ; then
+    cd "$TRAVIS_BUILD_DIR"/../fred &&
+    # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
+    if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then
+      rm ./gradlew &&
+      ln -s "$(which gradle)" ./gradlew
+    fi &&
+    # TODO: freenet.jar won't contain class Version if we don't run the
+    # clean task in a separate execution of Gradle. Why?
+    ./gradlew clean &&
+    # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
+    # needs - to build/output/
+    ./gradlew jar copyRuntimeLibs -x test &&
+    cd "$TRAVIS_BUILD_DIR"
+  else
+    echo "No changes at fred, not recompiling."
+  fi
+
+# Compile and test WoT
+script:
+  - echo 'Checksums of dependencies:' ; sha256sum ../fred/build/output/*
+  - ant
 
 jdk:
   - oraclejdk9

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -235,6 +235,20 @@ CHANGELOG about stuff only interesting for developers
   test code for it shows that the metric for how long full unit tests
   are typically may be "twice as much as the tested code itself."
 
+- [Code quality] Unit tests: Add scripts to benchmark the tests, speed
+                 one up (xor)
+
+  Produces sorted output like this:
+    1.234 sec package.ClassName1.testFunction1()
+    1.235 sec package.ClassName2.testFunction2()
+
+  Actual results (FIXME: Update once this build is finished):
+    https://gist.github.com/xor-freenet/28925cee6e44ad899060f91659250cd2
+
+  I will use this to speed up the tests.
+  A first improvement was done for testMaximalOwnIdentityXMLSize(), it
+  used to take 186 seconds on my machine, now takes 9.
+
 - 0006967: [Code quality] Unit tests: Introduce finite memory limit of
            512 MB (xor)
 

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -267,6 +267,26 @@ CHANGELOG about stuff only interesting for developers
   As the performance work is currently more important I will refrain
   from renaming all preexisting functions for a while.
 
+- 0007033: [Code quality] Speed up Travis CI builds: Don't recompile
+           fred if "git pull" changed nothing (xor)
+
+  The Travis CI build script of WoT usually obtains the most recent
+  development version of the Freenet core from GitHub and compiles it
+  before it compiles WoT itself against that.
+
+  Compilation of Freenet will now be omitted if its code has not changed
+  since the last build.
+  The execution time of a Travis CI build is thereby reduced by ~1
+  minute. That doesn't sound like much, but there is a time limit of
+  50 minutes per Travis build, so it is valuable.
+
+  What would be more beneficial is to obtain the Freenet JAR files from
+  the Maven repository which Freenet's Travis CI publishes them to.
+  I don't know whether publishing to Maven was implemented yet though,
+  the HTML of mvn.freenetproject.org sounds like it wasn't
+  - if it in fact was and someone knows how to use it please let me
+  know.
+
 THANKS TO
 
   - ArneBab

--- a/src/plugins/WebOfTrust/ui/terminal/WOTUtil.java
+++ b/src/plugins/WebOfTrust/ui/terminal/WOTUtil.java
@@ -35,7 +35,9 @@ import freenet.clients.fcp.FCPPluginMessage;
  * Command-line tool for maintenance and analysis of WOT databases.
  * 
  * Run and show syntax by:
- *     ./wotutil.sh
+ *     cd WoTRepository
+ *     ant
+ *     ./tools/wotutil
  */
 public final class WOTUtil {
 	

--- a/test/plugins/WebOfTrust/XMLTransformerTest.java
+++ b/test/plugins/WebOfTrust/XMLTransformerTest.java
@@ -87,19 +87,35 @@ public class XMLTransformerTest extends AbstractJUnit3BaseTest {
 		//System.out.println("Number of identities which fit into trust list XML: " + (count-1));
 		
 		/* Remove the following when using the commented out lines above */
-		mWoT.beginTrustListImport();
 		for(int i=0; i < XMLTransformer.MAX_IDENTITY_XML_TRUSTEE_AMOUNT; ++i) {
+			// Create Identitys and especially Trusts manually instead of using mWoT's functions as
+			// the resulting Score computations would make this test very slow (minutes).
+			
 			final Identity trustee = new Identity(mWoT,getRandomRequestURI(), 
 											getRandomLatinString(Identity.MAX_NICKNAME_LENGTH), true); 
-			trustee.storeAndCommit();
-			mWoT.setTrust(ownId, trustee, (byte)100, getRandomLatinString(Trust.MAX_TRUST_COMMENT_LENGTH));
+			trustee.storeWithoutCommit();
+			new Trust(mWoT, ownId, trustee, (byte)100, getRandomLatinString(Trust.MAX_TRUST_COMMENT_LENGTH))
+				.storeWithoutCommit();
 		}
-		mWoT.finishTrustListImport();
+		Persistent.checkedCommit(mWoT.getDatabase(), this);
 		
 		os = new ByteArrayOutputStream(XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
 		mTransformer.exportOwnIdentity(ownId, os);
+		byte[] result = os.toByteArray();
 		
-		assertTrue(os.toByteArray().length <= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
+		assertTrue(result.length <= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
+		// If this fails the total file size limit exceeds the need from the various limits for the
+		// contents and could be decreased.
+		assertTrue(result.length >= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE * 0.8f);
+		
+		// Since we created the Trusts manually without computing Scores the Score database is now
+		// incorrect, which would result in failure of super.tearDown() because it tests the
+		// correctness.
+		// Thus delete the Trusts again.
+		for(Trust trust : mWoT.getAllTrusts())
+			trust.deleteWithoutCommit();
+		Persistent.checkedCommit(mWoT.getDatabase(), this);
+		
 		/* End of "remove-this" part */
 	}
 

--- a/tools/benchmark-unit-tests
+++ b/tools/benchmark-unit-tests
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+if [ ! -e "build.xml" ] && [ -e "../build.xml" ] ; then
+	cd ..
+fi
+
+TESTCASE=( "-Dtest.skip=false" )
+if [ $# = 1 ] ; then
+	TESTCASE+=( "-Dtest.class=$1" )
+fi
+
+ant clean &> /dev/null
+ant "${TESTCASE[@]}" -Dtest.coverage=false |
+	awk '
+		/\[junit\] Running (.*)/ { testsuite=$3 }
+		/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+	sort --numeric --key=1

--- a/tools/wotutil
+++ b/tools/wotutil
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if [ ! -e dist/WebOfTrust.jar ] && [ -e ../dist/WebOfTrust.jar ] ; then
+	cd ..
+fi
+
 java -Xmx1024M  -classpath ../fred/lib/bcprov.jar:../fred/lib/freenet/freenet-ext.jar:../fred/dist/freenet.jar:dist/WebOfTrust.jar plugins.WebOfTrust.ui.terminal.WOTUtil "$@"


### PR DESCRIPTION
Based upon #3, please merge that first.  

Adds script `tools/benchmark-unit-tests` to provide a sorted list of how many seconds each test takes.

As a conclusion from that it also improves the runtime of `testMaximalOwnIdentityXMLSize()` from 186 to 9 seconds since it unnecessarily was one of the slowest test cases.

Please merge this into `next` with fast foward.