### PR TITLE
Speed up the unit tests by up to 14 minutes

### DIFF
--- a/.travis.upload-jar-to-freenet.sh
+++ b/.travis.upload-jar-to-freenet.sh
@@ -58,7 +58,7 @@ echo "Uploading WoT JAR to $URI..."
 
 # TODO: As of 2018-05-30 fcpupload's "--timeout" doesn't work, using coreutils' timeout, try again later
 # TODO: As of 2018-05-30 fcpupload's "--compress" also doesn't work.
-if ! time timeout 30m fcpupload --wait "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+if ! time timeout 30m fcpupload --wait --realtime "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
 	echo "Uploading WebOfTrust.jar to Freenet failed!" >&2
 	
 	# The commented out lines are for debugging fcpupload's "--spawn".

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,42 @@ cache:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
 
-before_install:
+# Get/update Freenet Git repository
+install:
   - cd "$TRAVIS_BUILD_DIR"/..
-  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred ; else cd fred ; git pull ; cd .. ; fi
+  - |
+    if [ ! -e fred/.git ] ; then # Must check subdir, main one will be created by Travis cache config.
+      FRED_UPDATED=1
+      git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred
+    fi
   - cd fred
-  - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
-  # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
-  - if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then rm ./gradlew && ln -s "$(which gradle)" ./gradlew ; fi
-  # TODO: freenet.jar won't contain class Version if we don't run the
-  # clean task in a separate execution of Gradle. Why?
-  - ./gradlew clean
-  # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
-  # needs - to build/output/
-  - ./gradlew jar copyRuntimeLibs -x test
+  - git fetch && if [ "$(git rev-parse @)" != "$(git rev-parse @{u})" ] ; then FRED_UPDATED=1 ; git pull ; fi
   - cd "$TRAVIS_BUILD_DIR"
-  # Print the checksums of the WoT dependencies - for debugging
-  - sha256sum ../fred/build/output/*
 
-script: ant
+# Compile Freenet Git repository
+before_script: |
+  if [ "$FRED_UPDATED" = 1 ] ; then
+    cd "$TRAVIS_BUILD_DIR"/../fred &&
+    # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
+    if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then
+      rm ./gradlew &&
+      ln -s "$(which gradle)" ./gradlew
+    fi &&
+    # TODO: freenet.jar won't contain class Version if we don't run the
+    # clean task in a separate execution of Gradle. Why?
+    ./gradlew clean &&
+    # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
+    # needs - to build/output/
+    ./gradlew jar copyRuntimeLibs -x test &&
+    cd "$TRAVIS_BUILD_DIR"
+  else
+    echo "No changes at fred, not recompiling."
+  fi
+
+# Compile and test WoT
+script:
+  - echo 'Checksums of dependencies:' ; sha256sum ../fred/build/output/*
+  - ant
 
 jdk:
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,24 @@ before_script: |
       rm ./gradlew &&
       ln -s "$(which gradle)" ./gradlew
     fi &&
+    if [[ "$TRAVIS_JDK_VERSION" = "openjdk9" || "$TRAVIS_JDK_VERSION" = "openjdk10" ]] ; then
+      # Workaround for Gradle failing on openjdk9 and above with:
+      #   sun.security.validator.ValidatorException: PKIX path building failed: [...]
+      # TODO: Code quality: Added 2018-09-26, remove after some time and see if it works without this.
+      USE_SYSTEM_CERTS=1 &&
+      mv "${JAVA_HOME}/lib/security/cacerts" "${JAVA_HOME}/lib/security/cacerts.jdk" &&
+      ln -s '/etc/ssl/certs/java/cacerts' "${JAVA_HOME}/lib/security/cacerts"
+    fi &&
     # TODO: freenet.jar won't contain class Version if we don't run the
     # clean task in a separate execution of Gradle. Why?
     ./gradlew clean &&
     # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
     # needs - to build/output/
     ./gradlew jar copyRuntimeLibs -x test &&
+    if [ "$USE_SYSTEM_CERTS" = 1 ] ; then
+        rm "${JAVA_HOME}/lib/security/cacerts" &&
+        mv "${JAVA_HOME}/lib/security/cacerts.jdk" "${JAVA_HOME}/lib/security/cacerts"
+    fi &&
     cd "$TRAVIS_BUILD_DIR"
   else
     echo "No changes at fred, not recompiling."
@@ -68,14 +80,20 @@ before_script: |
 # Compile and test WoT
 script:
   - echo 'Checksums of dependencies:' ; sha256sum ../fred/build/output/*
+  # Don't allow Travis to override the low memory limit we set in Ant with a higher one.
+  - unset _JAVA_OPTIONS
   - ant
 
 jdk:
+  - oraclejdk10
   - oraclejdk9
   - oraclejdk8
+  - openjdk10
+  - openjdk9
   - openjdk8
   - openjdk7
-  # openjdk9: As of 2018-05-12 isn't available on Travis yet.
+  # oraclejdk11: As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
+  # openjdk11:   As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
   # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
 
 deploy:

--- a/build.xml
+++ b/build.xml
@@ -337,6 +337,8 @@
 				file="${build-test-coverage}/cobertura.ser" if:true="${test.coverage}"/>
 			<sysproperty key="extensiveTesting" value="${extensiveTesting}" />
 			<jvmarg value="-Djava.awt.headless=true"/>
+			<!-- See IS_UNIT_TEST at class Configuration -->
+			<jvmarg value="-Dis_WOT_unit_test=true"/>
 			<!-- Pass the name of the JAR to the tests so they can load it into a fred instance -->
 			<jvmarg value="-DWOT_test_jar=${build-test-jar}"/>
 		</junit>
@@ -374,6 +376,8 @@
 			
 			<sysproperty key="extensiveTesting" value="${extensiveTesting}" />
 			<jvmarg value="-Djava.awt.headless=true"/>
+			<!-- See IS_UNIT_TEST at class Configuration -->
+			<jvmarg value="-Dis_WOT_unit_test=true"/>
 			<!-- Pass the name of the JAR to the tests so they can load it into a fred instance -->
 			<jvmarg value="-DWOT_test_jar=${build-test-jar}"/>
 		</junit>

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -238,7 +238,11 @@ CHANGELOG about stuff only interesting for developers
 - [Code quality] Unit tests: Add scripts to benchmark the tests, speed
                  one up (xor)
 
-  Produces sorted output like this:
+  Scripts were added to the tools/ directory which support:
+  - benchmarking unit tests locally when compiling.
+  - processing log files from Travis CI to produce benchmark results.
+
+  They produce sorted output like this:
     1.234 sec package.ClassName1.testFunction1()
     1.235 sec package.ClassName2.testFunction2()
 
@@ -272,6 +276,22 @@ CHANGELOG about stuff only interesting for developers
 
   FYI you can use e.g. jVisualVM to watch the memory usage and GC
   activity of Freenet.
+
+- Code quality: Travis CI: Test against most recent Java versions (xor)
+
+  The cloud service now runs the unit tests periodically against:
+  - oraclejdk10 (new)
+  - oraclejdk9
+  - oraclejdk8
+  - openjdk10 (new)
+  - openjdk9 (new)
+  - openjdk8
+  - openjdk7
+
+  This is the maximal set of Java versions which are both supported by
+  Freenet and Travis CI as of 2018-09-26.
+  Notably the new Java 11 is not tested yet due to Freenet's Gradle not
+  working on it.
 
 - 0006934: [Code quality] Replace "WithoutCommit" function name suffixes
            with "@NeedsTransaction" annotation (xor)

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -235,6 +235,20 @@ CHANGELOG about stuff only interesting for developers
   test code for it shows that the metric for how long full unit tests
   are typically may be "twice as much as the tested code itself."
 
+- [Code quality] Unit tests: Add scripts to benchmark the tests, speed
+                 one up (xor)
+
+  Produces sorted output like this:
+    1.234 sec package.ClassName1.testFunction1()
+    1.235 sec package.ClassName2.testFunction2()
+
+  Actual results (FIXME: Update once this build is finished):
+    https://gist.github.com/xor-freenet/28925cee6e44ad899060f91659250cd2
+
+  I will use this to speed up the tests.
+  A first improvement was done for testMaximalOwnIdentityXMLSize(), it
+  used to take 186 seconds on my machine, now takes 9.
+
 - 0006967: [Code quality] Unit tests: Introduce finite memory limit of
            512 MB (xor)
 

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -267,6 +267,26 @@ CHANGELOG about stuff only interesting for developers
   As the performance work is currently more important I will refrain
   from renaming all preexisting functions for a while.
 
+- 0007033: [Code quality] Speed up Travis CI builds: Don't recompile
+           fred if "git pull" changed nothing (xor)
+
+  The Travis CI build script of WoT usually obtains the most recent
+  development version of the Freenet core from GitHub and compiles it
+  before it compiles WoT itself against that.
+
+  Compilation of Freenet will now be omitted if its code has not changed
+  since the last build.
+  The execution time of a Travis CI build is thereby reduced by ~1
+  minute. That doesn't sound like much, but there is a time limit of
+  50 minutes per Travis build, so it is valuable.
+
+  What would be more beneficial is to obtain the Freenet JAR files from
+  the Maven repository which Freenet's Travis CI publishes them to.
+  I don't know whether publishing to Maven was implemented yet though,
+  the HTML of mvn.freenetproject.org sounds like it wasn't
+  - if it in fact was and someone knows how to use it please let me
+  know.
+
 THANKS TO
 
   - ArneBab

--- a/src/plugins/WebOfTrust/Configuration.java
+++ b/src/plugins/WebOfTrust/Configuration.java
@@ -41,6 +41,18 @@ public final class Configuration extends Persistent {
 	public final static transient long DEFAULT_VERIFY_SCORES_INTERVAL = TimeUnit.DAYS.toMillis(28);
 
 	/**
+	 * If this is true then batch processing delays of various subsystems will be set to low values.
+	 * ATTENTION: DO NOT use this for any significant program logic decisions! Unit tests should
+	 * not behave different to the real product if possible!
+	 * 
+	 * Please notice that this requires launching the JVM with "-Dis_WOT_unit_test=true".
+	 * This is currently done by the Ant builder, but your IDE might not do it without config.
+	 * (We're intentionally not determining the value by having the tests set this variable directly
+	 * because that would imply that it cannot be final, which would prevent usage of it in other
+	 * static final variables and also disallow compiler optimizations.) */
+	public final static transient boolean IS_UNIT_TEST = Boolean.getBoolean("is_WOT_unit_test");
+
+	/**
 	 * The database format version of this WoT-database.
 	 * Stored in a primitive integer field to ensure that db4o does not lose it - I've observed the HashMaps to be null suddenly sometimes :(
 	 */

--- a/src/plugins/WebOfTrust/IdentityFetcher.java
+++ b/src/plugins/WebOfTrust/IdentityFetcher.java
@@ -6,6 +6,10 @@
 
 package plugins.WebOfTrust;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static plugins.WebOfTrust.Configuration.IS_UNIT_TEST;
+
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -64,7 +68,8 @@ public final class IdentityFetcher implements USKRetrieverCallback, PrioRunnable
     /**
      * Will be used as delay for the {@link DelayedBackgroundJob} which schedules processing of
      * {@link IdentityFetcherCommand}s. */
-	private static final long PROCESS_COMMANDS_DELAY = 60 * 1000;
+	private static final long PROCESS_COMMANDS_DELAY =
+		IS_UNIT_TEST ? SECONDS.toMillis(1) : MINUTES.toMillis(1);
 
 	/**
 	 * If true, the fetcher will not only fetch the latest editions of Identitys, but also old

--- a/src/plugins/WebOfTrust/IdentityFileProcessor.java
+++ b/src/plugins/WebOfTrust/IdentityFileProcessor.java
@@ -4,9 +4,9 @@
 package plugins.WebOfTrust;
 
 import static freenet.support.TimeUtil.formatTime;
-
-import java.util.concurrent.TimeUnit;
-
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static plugins.WebOfTrust.Configuration.IS_UNIT_TEST;
 import plugins.WebOfTrust.IdentityFileQueue.IdentityFileStream;
 import plugins.WebOfTrust.util.jobs.BackgroundJob;
 import plugins.WebOfTrust.util.jobs.DelayedBackgroundJob;
@@ -50,7 +50,8 @@ public final class IdentityFileProcessor implements DelayedBackgroundJob {
 	 * To find a reasonable default, use an infinite processing delay together with a fresh, empty
 	 * database to see how much deduplication is the maximal possible value. Also see
 	 * https://bugs.freenetproject.org/view.php?id=6555 */
-	public static final long PROCESSING_DELAY_MILLISECONDS = TimeUnit.MINUTES.toMillis(1);
+	public static final long PROCESSING_DELAY_MILLISECONDS
+		= IS_UNIT_TEST ? SECONDS.toMillis(1) : MINUTES.toMillis(1);
 
 	/** We consume the files of this queue when it calls our {@link #triggerExecution()}. */
 	private final IdentityFileQueue mQueue;

--- a/src/plugins/WebOfTrust/IdentityInserter.java
+++ b/src/plugins/WebOfTrust/IdentityInserter.java
@@ -142,13 +142,12 @@ public final class IdentityInserter extends TransferThread {
 						long maxDelayedInsertTime = identity.getLastInsertDate().getTime() + MAX_DELAY_BEFORE_INSERT; 
 						
 						if(CurrentTimeUTC.getInMillis() > Math.min(minDelayedInsertTime, maxDelayedInsertTime)) {
-							if(logDEBUG) Logger.debug(this, "Starting insert of " + identity.getNickname() + " (" + identity.getInsertURI() + ")");
 							insert(identity);
 						} else {
 							long lastChangeBefore = (CurrentTimeUTC.getInMillis() - identity.getLastChangeDate().getTime()) / (60*1000);
 							long lastInsertBefore = (CurrentTimeUTC.getInMillis() - identity.getLastInsertDate().getTime()) / (60*1000); 
 							
-							if(logDEBUG) Logger.debug(this, "Delaying insert of " + identity.getNickname() + " (" + identity.getInsertURI() + "), " +
+							if(logDEBUG) Logger.debug(this, "Delaying insert of identity '" + identity.getNickname() + "', " +
 									"last change: " + lastChangeBefore + "min ago, last insert: " + lastInsertBefore + "min ago");
 						}
 					} catch (Exception e) {
@@ -188,7 +187,10 @@ public final class IdentityInserter extends TransferThread {
 			addInsert(pu);
 			tempB = null;
 			
-			if(logDEBUG) Logger.debug(this, "Started insert of identity '" + identity.getNickname() + "'");
+			if(logDEBUG) {
+				Logger.debug(this, "Started insert of identity '" + identity.getNickname() + "' to "
+					+ ib.desiredURI.deriveRequestURIFromInsertURI());
+			}
 		}
 		catch(Exception e) {
 			Logger.error(this, "Error during insert of identity '" + identity.getNickname() + "'", e);

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -106,13 +106,9 @@ public final class WebOfTrust extends WebOfTrustInterface
 
 	/** The relative path of the plugin on Freenet's web interface */
 	public static final String SELF_URI = "/WebOfTrust";
-
-	/** Package-private method to allow unit tests to bypass some assert()s */
 	
 	public static final String DATABASE_FILENAME =  WebOfTrustInterface.WOT_NAME + ".db4o"; 
 	public static final int DATABASE_FORMAT_VERSION = 7;
-	
-	
 
 	/* References from the node */
 	

--- a/src/plugins/WebOfTrust/introduction/IntroductionClient.java
+++ b/src/plugins/WebOfTrust/introduction/IntroductionClient.java
@@ -3,7 +3,11 @@
  * any later version). See http://www.gnu.org/ for details of the GPL. */
 package plugins.WebOfTrust.introduction;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static plugins.WebOfTrust.Configuration.IS_UNIT_TEST;
+import static plugins.WebOfTrust.util.MathUtil.toIntExact;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,15 +71,16 @@ import freenet.support.io.ResumeFailedException;
  * @author xor (xor@freenetproject.org)
  */
 public final class IntroductionClient extends TransferThread  {
-	
-	private static final int STARTUP_DELAY = 3 * 60 * 1000;
-	private static final int THREAD_PERIOD = 1 * 60 * 60 * 1000; 
-	
+
+	private static final int STARTUP_DELAY = toIntExact(MINUTES.toMillis(3));
+	private static final int THREAD_PERIOD = toIntExact(HOURS.toMillis(1));
+
 	/**
 	 * A call to getPuzzles() wakes up the puzzle downloader thread to download new puzzles. This constant specifies the minimal delay between two wake-ups.
 	 */
-	private static final int MINIMAL_SLEEP_TIME = 10 * 60 * 1000;
-	
+	private static final long MINIMAL_SLEEP_TIME
+		= IS_UNIT_TEST ? SECONDS.toMillis(1)  : MINUTES.toMillis(10);
+
 	/* TODO: Maybe implement backward-downloading of puzzles, currently we only download puzzles of today.
 	/* public static final byte PUZZLE_DOWNLOAD_BACKWARDS_DAYS = IntroductionServer.PUZZLE_INVALID_AFTER_DAYS - 1; */
 	
@@ -206,7 +211,11 @@ public final class IntroductionClient extends TransferThread  {
 			long timeSinceLastIteration = (time - mLastIterationTime);
 			
 			if(timeSinceLastIteration < MINIMAL_SLEEP_TIME) {
-			    nextIteration(MINIMAL_SLEEP_TIME - timeSinceLastIteration);
+				if(logMINOR) {
+					Logger.minor(this,
+						"iterate(): MINIMAL_SLEEP_TIME not expired, postponing unimportant tasks!");
+				}
+				nextIteration(MINIMAL_SLEEP_TIME - timeSinceLastIteration);
 				return;
 			}
 			

--- a/src/plugins/WebOfTrust/ui/terminal/WOTUtil.java
+++ b/src/plugins/WebOfTrust/ui/terminal/WOTUtil.java
@@ -35,7 +35,9 @@ import freenet.clients.fcp.FCPPluginMessage;
  * Command-line tool for maintenance and analysis of WOT databases.
  * 
  * Run and show syntax by:
- *     ./wotutil.sh
+ *     cd WoTRepository
+ *     ant
+ *     ./tools/wotutil
  */
 public final class WOTUtil {
 	

--- a/src/plugins/WebOfTrust/util/MathUtil.java
+++ b/src/plugins/WebOfTrust/util/MathUtil.java
@@ -1,0 +1,17 @@
+package plugins.WebOfTrust.util;
+
+public final class MathUtil {
+	/**
+	 * Casts the given value to integer, but throws {@link ArithmeticException} if it is too large
+	 * for an integer.
+	 * 
+	 * TODO: Code quality: Java 8: Replace with Math.toIntExact(). */
+	public static int toIntExact(long value) {
+		int result = (int)value;
+		
+		if(result != value)
+			throw new ArithmeticException ("Too large: " + value);
+		
+		return result;
+	}
+}

--- a/test/plugins/WebOfTrust/AbstractJUnit3BaseTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit3BaseTest.java
@@ -42,6 +42,11 @@ import freenet.keys.InsertableClientSSK;
 @Deprecated
 public class AbstractJUnit3BaseTest extends TestCase {
 
+	static {
+		assertTrue("Please launch the JVM with -Dis_WOT_unit_test=true",
+			Configuration.IS_UNIT_TEST);
+	}
+
 	protected WebOfTrust mWoT;
 	
 	protected RandomSource mRandom;

--- a/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
@@ -49,6 +49,11 @@ import freenet.keys.InsertableClientSSK;
     +   "they likely won't be ignored. But then also check that to make sure.")
 public abstract class AbstractJUnit4BaseTest {
 
+	static {
+		assertTrue("Please launch the JVM with -Dis_WOT_unit_test=true",
+			Configuration.IS_UNIT_TEST);
+	}
+
     protected RandomSource mRandom;
     
     @Rule

--- a/test/plugins/WebOfTrust/XMLTransformerTest.java
+++ b/test/plugins/WebOfTrust/XMLTransformerTest.java
@@ -87,19 +87,35 @@ public class XMLTransformerTest extends AbstractJUnit3BaseTest {
 		//System.out.println("Number of identities which fit into trust list XML: " + (count-1));
 		
 		/* Remove the following when using the commented out lines above */
-		mWoT.beginTrustListImport();
 		for(int i=0; i < XMLTransformer.MAX_IDENTITY_XML_TRUSTEE_AMOUNT; ++i) {
+			// Create Identitys and especially Trusts manually instead of using mWoT's functions as
+			// the resulting Score computations would make this test very slow (minutes).
+			
 			final Identity trustee = new Identity(mWoT,getRandomRequestURI(), 
 											getRandomLatinString(Identity.MAX_NICKNAME_LENGTH), true); 
-			trustee.storeAndCommit();
-			mWoT.setTrust(ownId, trustee, (byte)100, getRandomLatinString(Trust.MAX_TRUST_COMMENT_LENGTH));
+			trustee.storeWithoutCommit();
+			new Trust(mWoT, ownId, trustee, (byte)100, getRandomLatinString(Trust.MAX_TRUST_COMMENT_LENGTH))
+				.storeWithoutCommit();
 		}
-		mWoT.finishTrustListImport();
+		Persistent.checkedCommit(mWoT.getDatabase(), this);
 		
 		os = new ByteArrayOutputStream(XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
 		mTransformer.exportOwnIdentity(ownId, os);
+		byte[] result = os.toByteArray();
 		
-		assertTrue(os.toByteArray().length <= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
+		assertTrue(result.length <= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE);
+		// If this fails the total file size limit exceeds the need from the various limits for the
+		// contents and could be decreased.
+		assertTrue(result.length >= XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE * 0.8f);
+		
+		// Since we created the Trusts manually without computing Scores the Score database is now
+		// incorrect, which would result in failure of super.tearDown() because it tests the
+		// correctness.
+		// Thus delete the Trusts again.
+		for(Trust trust : mWoT.getAllTrusts())
+			trust.deleteWithoutCommit();
+		Persistent.checkedCommit(mWoT.getDatabase(), this);
+		
 		/* End of "remove-this" part */
 	}
 

--- a/test/plugins/WebOfTrust/introduction/IntroductionClientTest.java
+++ b/test/plugins/WebOfTrust/introduction/IntroductionClientTest.java
@@ -172,11 +172,11 @@ public final class IntroductionClientTest extends AbstractMultiNodeTest {
 		
 		// Not necessary: createOwnIdentity() does it.
 		/*
-			// Speed up generation / upload of the puzzle.
+			// Speed up download of the puzzle.
 			client.nextIteration();
 		*/
 		
-		System.out.println("IntroductionClientTest: Waiting for puzzle to downloaded...");
+		System.out.println("IntroductionClientTest: Waiting for puzzle to be downloaded...");
 		StopWatch downloadTime = new StopWatch();
 		do {
 			synchronized(clientWoT) {

--- a/tools/benchmark-unit-tests
+++ b/tools/benchmark-unit-tests
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+if [ ! -e "build.xml" ] && [ -e "../build.xml" ] ; then
+	cd ..
+fi
+
+TESTCASE=( "-Dtest.skip=false" )
+if [ $# = 1 ] ; then
+	TESTCASE+=( "-Dtest.class=$1" )
+fi
+
+ant clean &> /dev/null
+ant "${TESTCASE[@]}" -Dtest.coverage=false |
+	awk '
+		/\[junit\] Running (.*)/ { testsuite=$3 }
+		/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+	sort --numeric --key=1

--- a/tools/benchmark-unit-tests-from-travis
+++ b/tools/benchmark-unit-tests-from-travis
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+if [ $# != 1 ] ; then
+	echo "Syntax: $0 TRAVIS_CI_LOGFILE" >&2
+	exit 1
+fi
+
+awk '/\$ ant/ {p=1} ; /BUILD SUCCESSFUL/ {p=3} ; p==2 {print $0} ; p==1 {p=2}' < "$1" |
+tr -d '\r' |
+awk '
+	/\[junit\] Running (.*)/ { testsuite=$3 }
+	/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+sort --numeric --key=1

--- a/tools/wotutil
+++ b/tools/wotutil
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if [ ! -e dist/WebOfTrust.jar ] && [ -e ../dist/WebOfTrust.jar ] ; then
+	cd ..
+fi
+
 java -Xmx1024M  -classpath ../fred/lib/bcprov.jar:../fred/lib/freenet/freenet-ext.jar:../fred/dist/freenet.jar:dist/WebOfTrust.jar plugins.WebOfTrust.ui.terminal.WOTUtil "$@"


### PR DESCRIPTION
This is based on #5, please merge that first.

Speeds up:
- IntroductionClientTest by up to 12 minutes
- IdentityFetcherTest by up to 2 minutes

These numbers are the theoretical limit, they may average out to less in
practice.

Please merge this into next with fast-forward.