### PR TITLE
Gradle: Add script to validate JAR against Ant

### DIFF
--- a/tools/compare-gradle-jar-with-ant-jar
+++ b/tools/compare-gradle-jar-with-ant-jar
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+from_ant="$(mktemp --directory --suffix=.from-ant)"
+from_gradle="$(mktemp --directory --suffix=.from-gradle)"
+trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+
+# FIXME: Also validate the unit test JAR
+jar='dist/WebOfTrust.jar'
+
+echo "Building with Ant..."
+gradle clean &> /dev/null
+! [ -e "$jar" ]
+ant -Dtest.skip=true clean dist &> /dev/null
+unzip -qq "$jar" -d "$from_ant"
+
+echo "Building with Gradle..."
+ant clean &> /dev/null
+! [ -e "$jar" ]
+gradle clean jar &> /dev/null
+unzip -qq "$jar" -d "$from_gradle"
+
+echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
+shopt -s globstar
+shopt -s nullglob
+# These are non-executable classes which only exist as a place to hold JavaDoc, Gradle correctly
+# excludes them, so ignore them.
+rm --force -- "$from_ant"/**/package-info.class
+# Ant for some reason not only includes Version.class but also .java, it shouldn't, so ignore it.
+rm --force -- "$from_ant"/**/Version.java
+
+echo "Removing Ant-only stuff from MANIFEST.MF..."
+sed --regexp-extended --expression='/^Ant(.*)$/d' \
+	--expression='/^Created-By(.*)/d' \
+	--in-place "$from_ant/META-INF/MANIFEST.MF"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
+
+echo "Diffing..."
+if diff --recursive "$from_ant" "$from_gradle" ; then
+	echo "JARs are identical!"
+	exit 0
+else
+	echo "JARs do not match!" >&2
+	exit 1
+fi


### PR DESCRIPTION
This provides a script tools/compare-gradle-jar-with-ant-jar which produces a WoT JAR both with Ant and Gradle, unzips each, and diffs their containing data - while ignoring valid differences.  
This ensures the Gradle builder works properly.

Please merge this into `next` with `--ff-only`.

WARNING: Please consider the Gradle builder as experimental until the other -part* branches have been submitted and keep using Ant meanwhile.

Remaining work upon Gradle:
- Compare the unit test JAR
- Check if Gradle runs the same set of unit tests as Ant
- Make Travis CI use it
- Update the changelog
