### PR TITLE
Gradle: Amend selftest script to also validate unit test JAR against Ant

### DIFF
--- a/tools/compare-gradle-jar-with-ant-jar
+++ b/tools/compare-gradle-jar-with-ant-jar
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+from_ant="$(mktemp --directory --suffix=.from-ant)"
+from_gradle="$(mktemp --directory --suffix=.from-gradle)"
+trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+
+# FIXME: Also validate the unit test JAR
+jar='dist/WebOfTrust.jar'
+
+echo "Building with Ant..."
+gradle clean &> /dev/null
+! [ -e "$jar" ]
+ant -Dtest.skip=true clean dist &> /dev/null
+unzip -qq "$jar" -d "$from_ant"
+
+echo "Building with Gradle..."
+ant clean &> /dev/null
+! [ -e "$jar" ]
+gradle clean jar &> /dev/null
+unzip -qq "$jar" -d "$from_gradle"
+
+echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
+shopt -s globstar
+shopt -s nullglob
+# These are non-executable classes which only exist as a place to hold JavaDoc, Gradle correctly
+# excludes them, so ignore them.
+rm --force -- "$from_ant"/**/package-info.class
+# Ant for some reason not only includes Version.class but also .java, it shouldn't, so ignore it.
+rm --force -- "$from_ant"/**/Version.java
+
+echo "Removing Ant-only stuff from MANIFEST.MF..."
+sed --regexp-extended --expression='/^Ant(.*)$/d' \
+	--expression='/^Created-By(.*)/d' \
+	--in-place "$from_ant/META-INF/MANIFEST.MF"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
+
+echo "Diffing..."
+if diff --recursive "$from_ant" "$from_gradle" ; then
+	echo "JARs are identical!"
+	exit 0
+else
+	echo "JARs do not match!" >&2
+	exit 1
+fi

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -4,23 +4,25 @@ set -o errexit
 set -o errtrace
 trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
-from_ant="$(mktemp --directory --suffix=.from-ant)"
-from_gradle="$(mktemp --directory --suffix=.from-gradle)"
-trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
 
-# FIXME: Also validate the unit test JAR
-jar='dist/WebOfTrust.jar'
+check_jar() {
+local jar="$1"
+local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"
+local from_gradle="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-gradle)"
 
+echo "Testing jar: $jar"
 echo "Building with Ant..."
 gradle clean &> /dev/null
-! [ -e "$jar" ]
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
 ant -Dtest.skip=true clean dist &> /dev/null
 unzip -qq "$jar" -d "$from_ant"
 
 echo "Building with Gradle..."
 ant clean &> /dev/null
-! [ -e "$jar" ]
-gradle clean jar &> /dev/null
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
+gradle clean jar testJar &> /dev/null
 unzip -qq "$jar" -d "$from_gradle"
 
 echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
@@ -40,11 +42,18 @@ sed --regexp-extended --expression='/^Ant(.*)$/d' \
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
 
-echo "Diffing..."
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
 if diff --recursive "$from_ant" "$from_gradle" ; then
 	echo "JARs are identical!"
-	exit 0
+	return 0
 else
-	echo "JARs do not match!" >&2
-	exit 1
+	echo "JARs do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	return 1
 fi
+}
+
+check_jar 'dist/WebOfTrust.jar'
+check_jar 'build-test/WebOfTrust-with-unit-tests.jar'


### PR DESCRIPTION
_This also contains the commits of the previous PR. Merge that first to only see the relevant diff here._
_As usual all PRs should be merged with `--ff-only` please._

There already was a script `tools/compare-gradle-jar-with-ant-jar` which produces a WoT JAR both with Ant and Gradle, unzips each, and diffs their containing data - while ignoring valid differences.

This script is hereby updated to also check the unit test JAR which both Ant and Gradle use to run the tests from.
This ensures all tests can be run with both builders.
An upcoming PR will also add a script to test whether they actually are run each.

To match its new purpose the script is renamed to `compare-gradle-jars-with-ant-jars`.

WARNING: Please consider the Gradle builder as experimental until the other -part* branches have been submitted and keep using Ant meanwhile.

Remaining work upon Gradle:
- Check if Gradle actually runs the same set of unit tests as Ant
- Make Travis CI use it
- Update the changelog