### PR TITLE
Gradle: Add script to validate the set of executed tests against Ant

### DIFF
--- a/tools/compare-gradle-jar-with-ant-jar
+++ b/tools/compare-gradle-jar-with-ant-jar
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+from_ant="$(mktemp --directory --suffix=.from-ant)"
+from_gradle="$(mktemp --directory --suffix=.from-gradle)"
+trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+
+# FIXME: Also validate the unit test JAR
+jar='dist/WebOfTrust.jar'
+
+echo "Building with Ant..."
+gradle clean &> /dev/null
+! [ -e "$jar" ]
+ant -Dtest.skip=true clean dist &> /dev/null
+unzip -qq "$jar" -d "$from_ant"
+
+echo "Building with Gradle..."
+ant clean &> /dev/null
+! [ -e "$jar" ]
+gradle clean jar &> /dev/null
+unzip -qq "$jar" -d "$from_gradle"
+
+echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
+shopt -s globstar
+shopt -s nullglob
+# These are non-executable classes which only exist as a place to hold JavaDoc, Gradle correctly
+# excludes them, so ignore them.
+rm --force -- "$from_ant"/**/package-info.class
+# Ant for some reason not only includes Version.class but also .java, it shouldn't, so ignore it.
+rm --force -- "$from_ant"/**/Version.java
+
+echo "Removing Ant-only stuff from MANIFEST.MF..."
+sed --regexp-extended --expression='/^Ant(.*)$/d' \
+	--expression='/^Created-By(.*)/d' \
+	--in-place "$from_ant/META-INF/MANIFEST.MF"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
+
+echo "Diffing..."
+if diff --recursive "$from_ant" "$from_gradle" ; then
+	echo "JARs are identical!"
+	exit 0
+else
+	echo "JARs do not match!" >&2
+	exit 1
+fi

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -4,23 +4,25 @@ set -o errexit
 set -o errtrace
 trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
-from_ant="$(mktemp --directory --suffix=.from-ant)"
-from_gradle="$(mktemp --directory --suffix=.from-gradle)"
-trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
 
-# FIXME: Also validate the unit test JAR
-jar='dist/WebOfTrust.jar'
+check_jar() {
+local jar="$1"
+local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"
+local from_gradle="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-gradle)"
 
+echo "Testing jar: $jar"
 echo "Building with Ant..."
 gradle clean &> /dev/null
-! [ -e "$jar" ]
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
 ant -Dtest.skip=true clean dist &> /dev/null
 unzip -qq "$jar" -d "$from_ant"
 
 echo "Building with Gradle..."
 ant clean &> /dev/null
-! [ -e "$jar" ]
-gradle clean jar &> /dev/null
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
+gradle clean jar testJar &> /dev/null
 unzip -qq "$jar" -d "$from_gradle"
 
 echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
@@ -40,11 +42,18 @@ sed --regexp-extended --expression='/^Ant(.*)$/d' \
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
 
-echo "Diffing..."
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
 if diff --recursive "$from_ant" "$from_gradle" ; then
 	echo "JARs are identical!"
-	exit 0
+	return 0
 else
-	echo "JARs do not match!" >&2
-	exit 1
+	echo "JARs do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	return 1
 fi
+}
+
+check_jar 'dist/WebOfTrust.jar'
+check_jar 'build-test/WebOfTrust-with-unit-tests.jar'

--- a/tools/compare-gradle-tests-with-ant-tests
+++ b/tools/compare-gradle-tests-with-ant-tests
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+from_ant="$(mktemp --tmpdir="$tmpdir" --suffix=.from-ant)"
+from_gradle="$(mktemp --tmpdir="$tmpdir" --suffix=.from-gradle)"
+
+echo "Testing with Ant..."
+gradle clean &> /dev/null
+ant -Dtest.skip=false clean dist |&
+	awk '
+		/\[junit\] Running (.*)/ { testsuite=$3 }
+		/\[junit\] Testcase: (.*) took (.*) sec/ { print testsuite "." $3 "()" }' |
+	sort > "$from_ant"
+
+echo "Testing with Gradle..."
+ant clean &> /dev/null
+gradle clean test |&
+	awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' |
+	sort > "$from_gradle"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle"
+
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
+if diff "$from_ant" "$from_gradle" ; then
+	echo "Executed tests are identical!"
+	exit 0
+else
+	echo "Executed tests do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	exit 1
+fi


### PR DESCRIPTION
_This also contains the commits of the previous PR. Merge that first to only see the relevant diff here._
_As usual all PRs should be merged with `--ff-only` please._

This provides a script `tools/compare-gradle-tests-with-ant-tests` which runs the unit tests with both Ant and Gradle and checks whether the same set of tests is run with each builder.

Ensuring that is a good idea because selecting unit tests to run is non-trivial:
Tests are not selected by e.g. a special, obvious flag "this is a test" which could be contained in the class files, but heuristically from their filenames.
Also not only are certain patterns whitelisted for being run as tests, but there is also blacklisting for other patterns.
Thus test selection is prone to errors and testing it is a good idea.

This script will currently actually fail due to a mismatch in the resulting test list - fortunately it is probably only a bug in the awk parsing of the Ant output, but that is present in other pre-existing scripts as well, so postponing the fix to a branch of its own.
Also shipping it as is to ensure that bug is documented publicly by the existence of the script.

WARNING: Please consider the Gradle builder as experimental until the other -part* branches have been submitted and keep using Ant meanwhile.

Remaining work upon Gradle:
- Investigate the failure of compare-gradle-tests-with-ant-tests.
- Apply the fix for the above to the related tools/* scripts
- Make Travis CI use Gradle
- Update the changelog
- Update the readme