### PR TITLE
Gradle: Fix test script compare-gradle-tests-with-ant-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,11 @@ script:
   # Don't allow Travis to override the low memory limit we set in Ant with a higher one.
   - unset _JAVA_OPTIONS
   - ant
+  # To test the Ant and Gradle builders against each other uncomment the following.
+  ## Use the same Gradle as fred to re-use the fixes we applied to it above
+  ## - ln -s "$TRAVIS_BUILD_DIR/../fred/gradlew"
+  ## - tools/compare-gradle-jars-with-ant-jars
+  ## - tools/compare-gradle-tests-with-ant-tests
 
 jdk:
   - oraclejdk9

--- a/tools/benchmark-unit-tests
+++ b/tools/benchmark-unit-tests
@@ -16,6 +16,8 @@ fi
 ant clean &> /dev/null
 ant "${TESTCASE[@]}" -Dtest.coverage=false |
 	awk '
+		length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
 		/\[junit\] Running (.*)/ { testsuite=$3 }
-		/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+		/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = $5 " " $6 " " testsuite "." $3 "()" }
+		END { if(length(outbuf) > 0) { print outbuf } }' |
 	sort --numeric --key=1

--- a/tools/benchmark-unit-tests-from-travis
+++ b/tools/benchmark-unit-tests-from-travis
@@ -12,6 +12,8 @@ fi
 awk '/\$ ant/ {p=1} ; /BUILD SUCCESSFUL/ {p=3} ; p==2 {print $0} ; p==1 {p=2}' < "$1" |
 tr -d '\r' |
 awk '
+	length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
 	/\[junit\] Running (.*)/ { testsuite=$3 }
-	/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+	/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = $5 " " $6 " " testsuite "." $3 "()" }
+	END { if(length(outbuf) > 0) { print outbuf } }' |
 sort --numeric --key=1

--- a/tools/compare-gradle-jar-with-ant-jar
+++ b/tools/compare-gradle-jar-with-ant-jar
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+from_ant="$(mktemp --directory --suffix=.from-ant)"
+from_gradle="$(mktemp --directory --suffix=.from-gradle)"
+trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+
+# FIXME: Also validate the unit test JAR
+jar='dist/WebOfTrust.jar'
+
+echo "Building with Ant..."
+gradle clean &> /dev/null
+! [ -e "$jar" ]
+ant -Dtest.skip=true clean dist &> /dev/null
+unzip -qq "$jar" -d "$from_ant"
+
+echo "Building with Gradle..."
+ant clean &> /dev/null
+! [ -e "$jar" ]
+gradle clean jar &> /dev/null
+unzip -qq "$jar" -d "$from_gradle"
+
+echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
+shopt -s globstar
+shopt -s nullglob
+# These are non-executable classes which only exist as a place to hold JavaDoc, Gradle correctly
+# excludes them, so ignore them.
+rm --force -- "$from_ant"/**/package-info.class
+# Ant for some reason not only includes Version.class but also .java, it shouldn't, so ignore it.
+rm --force -- "$from_ant"/**/Version.java
+
+echo "Removing Ant-only stuff from MANIFEST.MF..."
+sed --regexp-extended --expression='/^Ant(.*)$/d' \
+	--expression='/^Created-By(.*)/d' \
+	--in-place "$from_ant/META-INF/MANIFEST.MF"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
+
+echo "Diffing..."
+if diff --recursive "$from_ant" "$from_gradle" ; then
+	echo "JARs are identical!"
+	exit 0
+else
+	echo "JARs do not match!" >&2
+	exit 1
+fi

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -4,23 +4,25 @@ set -o errexit
 set -o errtrace
 trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
-from_ant="$(mktemp --directory --suffix=.from-ant)"
-from_gradle="$(mktemp --directory --suffix=.from-gradle)"
-trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
 
-# FIXME: Also validate the unit test JAR
-jar='dist/WebOfTrust.jar'
+check_jar() {
+local jar="$1"
+local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"
+local from_gradle="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-gradle)"
 
+echo "Testing jar: $jar"
 echo "Building with Ant..."
 gradle clean &> /dev/null
-! [ -e "$jar" ]
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
 ant -Dtest.skip=true clean dist &> /dev/null
 unzip -qq "$jar" -d "$from_ant"
 
 echo "Building with Gradle..."
 ant clean &> /dev/null
-! [ -e "$jar" ]
-gradle clean jar &> /dev/null
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
+gradle clean jar testJar &> /dev/null
 unzip -qq "$jar" -d "$from_gradle"
 
 echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
@@ -40,11 +42,18 @@ sed --regexp-extended --expression='/^Ant(.*)$/d' \
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
 
-echo "Diffing..."
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
 if diff --recursive "$from_ant" "$from_gradle" ; then
 	echo "JARs are identical!"
-	exit 0
+	return 0
 else
-	echo "JARs do not match!" >&2
-	exit 1
+	echo "JARs do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	return 1
 fi
+}
+
+check_jar 'dist/WebOfTrust.jar'
+check_jar 'build-test/WebOfTrust-with-unit-tests.jar'

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -7,6 +7,13 @@ trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 tmpdir="$(mktemp --directory)"
 trap 'rm -rf -- "$tmpdir"' EXIT
 
+if [ -e "./gradlew" ] ; then
+	echo "Found ./gradlew, using it instead of system's Gradle."
+	shopt -s expand_aliases
+	unalias -a
+	alias gradle=./gradlew
+fi
+
 check_jar() {
 local jar="$1"
 local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"

--- a/tools/compare-gradle-tests-with-ant-tests
+++ b/tools/compare-gradle-tests-with-ant-tests
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+from_ant="$(mktemp --tmpdir="$tmpdir" --suffix=.from-ant)"
+from_gradle="$(mktemp --tmpdir="$tmpdir" --suffix=.from-gradle)"
+
+echo "Testing with Ant..."
+gradle clean &> /dev/null
+ant -Dtest.skip=false clean dist |&
+	awk '
+		/\[junit\] Running (.*)/ { testsuite=$3 }
+		/\[junit\] Testcase: (.*) took (.*) sec/ { print testsuite "." $3 "()" }' |
+	sort > "$from_ant"
+
+echo "Testing with Gradle..."
+ant clean &> /dev/null
+gradle clean test |&
+	awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' |
+	sort > "$from_gradle"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle"
+
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
+if diff "$from_ant" "$from_gradle" ; then
+	echo "Executed tests are identical!"
+	exit 0
+else
+	echo "Executed tests do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	exit 1
+fi

--- a/tools/compare-gradle-tests-with-ant-tests
+++ b/tools/compare-gradle-tests-with-ant-tests
@@ -11,26 +11,44 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 from_ant="$(mktemp --tmpdir="$tmpdir" --suffix=.from-ant)"
 from_gradle="$(mktemp --tmpdir="$tmpdir" --suffix=.from-gradle)"
 
-echo "Testing with Ant..."
-gradle clean &> /dev/null
-ant -Dtest.skip=false clean dist |&
-	awk '
-		/\[junit\] Running (.*)/ { testsuite=$3 }
-		/\[junit\] Testcase: (.*) took (.*) sec/ { print testsuite "." $3 "()" }' |
-	sort > "$from_ant"
+if [ -e "./gradlew" ] ; then
+	echo "Found ./gradlew, using it instead of system's Gradle."
+	shopt -s expand_aliases
+	unalias -a
+	alias gradle=./gradlew
+fi
 
-echo "Testing with Gradle..."
-ant clean &> /dev/null
-gradle clean test |&
-	awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' |
-	sort > "$from_gradle"
+echo "Cleaning Gradle output and testing with Ant..."
+gradle clean
+ant -Dtest.skip=false clean dist |& tee "${from_ant}.raw"
+awk '
+	length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
+	/\[junit\] Running (.*)/ { testsuite=$3 }
+	/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = testsuite "." $3 "()" }
+	END { if(length(outbuf) > 0) { print outbuf } }' \
+	"${from_ant}.raw" | sort > "$from_ant"
+
+echo "Cleaning Ant output and testing with Gradle..."
+ant clean
+gradle clean test |& tee "${from_gradle}.raw"
+awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' \
+	"${from_gradle}.raw" | sort > "$from_gradle"
 
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle"
 
-echo "Diffing:"
+echo ""
 echo "Ant output:    $from_ant"
 echo "Gradle output: $from_gradle"
+
+ant_tests=$(wc -l "$from_ant" | cut -d' ' -f1)
+gradle_tests=$(wc -l "$from_gradle" | cut -d' ' -f1)
+[ "$ant_tests" -gt 0 ]
+[ "$gradle_tests" -gt 0 ]
+echo "Ant tests:     $ant_tests"
+echo "Gradle tests:  $gradle_tests"
+
+echo "Diffing:"
 if diff "$from_ant" "$from_gradle" ; then
 	echo "Executed tests are identical!"
 	exit 0


### PR DESCRIPTION
_This also contains the commits of the previous PR. Merge that first to only see the relevant diff here._  
_As usual all PRs should be merged with `--ff-only` please._

The script, as shipped by the previous branch, was failing due to a bug
in its parser of the Ant output.
It succeeds now, which validates that Gradle runs the same set of unit
tests as Ant.

The bug in the awk-based parsing of the Ant output has been fixed in the
related tools/* scripts as well.

This branch adds commented-out code to the Travis CI script which, along
with making them Travis-compatible, was used to test both
compare-gradle-tests-with-ant-tests and
compare-gradle-jars-with-ant-jars against all supported Java versions.
By that it is now guaranteed that the Gradle script is a fully valid
replacement for the Ant script's main purposes.

Nevertheless the Ant script will *not* be removed as it has more
features (most notably test coverage analysis).
I will continue maintaining both scripts until the Gradle one has the
same capabilities, and possibly beyond to provide developers with
freedom of choice.
Also having two different implementations of the same thing available
*and* tools to compare their results is a very sophisticated test,
which is a benefit of its own.

Remaining work upon Gradle:
- Make Travis CI use Gradle
- Make Eclipse use Gradle
- Fix incremental JAR building
- the in-code FIXMEs
- Update the changelog
- Update the readme