### PR TITLE
Travis CI: Speed up build time from ~ 1 hour to ~ 20 minutes

### DIFF
--- a/.travis.start-freenet.sh
+++ b/.travis.start-freenet.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+echo "Installing pyFreenet3..."
+pip3 install -U --user --egg pyFreenet3
+
+# FIXME: As of 2018-05-03 fcpupload's "--spawn" parameter doesn't work,
+# see https://bugs.freenetproject.org/view.php?id=7018 - so we start our
+# own node.
+# Once that is fixed don't start a node here - do so by reverting the
+# commit which added this FIXME.
+
+cd "$TRAVIS_BUILD_DIR"/../fred
+echo "Configuring node..."
+
+# Ignore Travis cache since seednodes may change.
+rm -f seednodes.fref
+# FIXME: Use fred's official URL once there is one
+wget https://github.com/ArneBab/lib-pyFreenet-staging/releases/download/spawn-ext-data/seednodes.fref
+
+# Use a non-standard port to not interfere with WoT unit tests.
+# (They should not be connecting to FCP by network, but let's be paranoid anyway.)
+FCP_PORT=23874
+
+cat << EOF > freenet.ini
+fcp.port=$FCP_PORT
+node.updater.enabled=false
+node.clientCacheType=ram
+node.storeType=ram
+fproxy.hasCompletedWizard=true
+security-levels.physicalThreatLevel=LOW
+security-levels.networkThreatLevel=LOW
+node.opennet.enabled=true
+node.outputBandwidthLimit=1048576
+node.inputBandwidthLimit=-1
+node.opennet.maxOpennetPeers=65
+node.load.threadLimit=1000
+logger.priority=NONE
+End
+EOF
+
+echo "Starting node..."
+java -Xmx512M -classpath 'build/output/*' -Djna.nosys=true freenet.node.NodeStarter \
+	&> freenet.WoT-JAR-upload-node.log &
+
+jobs -p > freenet.WoT-JAR-upload-node.pid

--- a/.travis.upload-jar-to-freenet.sh
+++ b/.travis.upload-jar-to-freenet.sh
@@ -6,44 +6,7 @@ trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
 FILENAME="WebOfTrust-$(git describe --always)-built-on-$TRAVIS_JDK_VERSION.jar"
 URI="CHK@/$FILENAME"
-
-echo "Installing pyFreenet3..."
-pip3 install -U --user --egg pyFreenet3
-
-# FIXME: As of 2018-05-03 fcpupload's "--spawn" parameter doesn't work,
-# see https://bugs.freenetproject.org/view.php?id=7018 - so we start our
-# own node.
-# Once that is fixed don't start a node here - do so by reverting the
-# commit which added this FIXME.
-
-cd "$TRAVIS_BUILD_DIR"/../fred
-echo "Configuring node..."
-
-# FIXME: Use fred's official URL once there is one
-wget https://github.com/ArneBab/lib-pyFreenet-staging/releases/download/spawn-ext-data/seednodes.fref
-
-cat << EOF > freenet.ini
-node.updater.enabled=false
-node.clientCacheType=ram
-node.storeType=ram
-fproxy.hasCompletedWizard=true
-security-levels.physicalThreatLevel=LOW
-security-levels.networkThreatLevel=LOW
-node.opennet.enabled=true
-node.outputBandwidthLimit=1048576
-node.inputBandwidthLimit=-1
-node.opennet.maxOpennetPeers=65
-node.load.threadLimit=1000
-logger.priority=NONE
-End
-EOF
-
-echo "Starting node..."
-java -Xmx512M -classpath 'build/output/*' -Djna.nosys=true freenet.node.NodeStarter &
-cd "$TRAVIS_BUILD_DIR"
-
-echo "Giving node 60s to boot..."
-sleep 60s
+FCP_PORT=23874
 
 echo "Uploading WoT JAR to $URI..."
 
@@ -56,14 +19,17 @@ echo "Uploading WoT JAR to $URI..."
 	done
 ) &
 
-# TODO: As of 2018-05-30 fcpupload's "--timeout" doesn't work, using coreutils' timeout, try again later
 # TODO: As of 2018-05-30 fcpupload's "--compress" also doesn't work.
-if ! time timeout 30m fcpupload --wait --realtime "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+if ! time fcpupload --fcpPort=$FCP_PORT --wait --realtime \
+		"$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+
 	echo "Uploading WebOfTrust.jar to Freenet failed!" >&2
 	
 	# The commented out lines are for debugging fcpupload's "--spawn".
 	#
-	# echo "Uploading WebOfTrust.jar to Freenet failed! Dumping wrapper.log, wrapper.conf and listing node dir..." >&2
+	# echo "Uploading WebOfTrust.jar to Freenet failed! Dumping diagnostic data..." >&2
+	# echo "Node stdout/stderr: " >&2
+	# cat "$TRAVIS_BUILD_DIR"/../fred/freenet.WoT-JAR-upload-node.log >&2
 	# echo "wrapper.log:" >&2
 	# cat "$HOME/.local/share/babcom-spawn-9486/wrapper.log" >&2
 	# echo "wrapper.conf:" >&2
@@ -74,12 +40,8 @@ if ! time timeout 30m fcpupload --wait --realtime "$URI" "$TRAVIS_BUILD_DIR/dist
 	exit 1
 fi
 
-# Can't use "kill $(jobs -p)" as that fails if a job exits in between
-jobs -p | xargs --no-run-if-empty kill || true
-
-if ! wait ; then
-	echo "Node exit code indicates error!" >&2
-	exit 1
-fi
+# TODO: Use pyFreenet for this
+echo "Stopping the Freenet node..."
+xargs kill < "$TRAVIS_BUILD_DIR"/../fred/freenet.WoT-JAR-upload-node.pid || true
 
 exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,11 @@ script:
   # Don't allow Travis to override the low memory limit we set in Ant with a higher one.
   - unset _JAVA_OPTIONS
   - ant
+  # To test the Ant and Gradle builders against each other uncomment the following.
+  ## Use the same Gradle as fred to re-use the fixes we applied to it above
+  ## - ln -s "$TRAVIS_BUILD_DIR/../fred/gradlew"
+  ## - tools/compare-gradle-jars-with-ant-jars
+  ## - tools/compare-gradle-tests-with-ant-tests
 
 jdk:
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,10 @@ before_script: |
       ln -s '/etc/ssl/certs/java/cacerts' "${JAVA_HOME}/lib/security/cacerts"
     fi &&
     # TODO: freenet.jar won't contain class Version if we don't run the
-    # clean task in a separate execution of Gradle. Why?
+    # clean task in a separate execution of Gradle. I.e. this wouldn't work:
+    #   $ gradle clean jar
+    # This is due to a bug in fred's Gradle script which could be fixed
+    # like this WoT commit did: 06c007204f40c712a398f0b58671f77fd9aeffd1
     ./gradlew clean &&
     # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
     # needs - to build/output/
@@ -81,12 +84,14 @@ before_script: |
 script:
   - set -o errexit
   - echo 'Checksums of dependencies:' ; sha256sum ../fred/build/output/*
-  # Don't allow Travis to override the low memory limit we set in Ant with a higher one.
+  # Don't allow Travis to override the low memory limit which our builder sets with a higher one.
   - unset _JAVA_OPTIONS
-  - ant
+  # Use Gradle instead of Ant as it supports using multiple CPU cores on the unit tests.
+  # Use the same Gradle as fred to re-use the fixes we applied to it above and because Travis'
+  # Gradle version is too old for Java >= 9.
+  - ln -sf "$TRAVIS_BUILD_DIR/../fred/gradlew"
+  - ./gradlew clean test jar
   # To test the Ant and Gradle builders against each other uncomment the following.
-  ## Use the same Gradle as fred to re-use the fixes we applied to it above
-  ## - ln -s "$TRAVIS_BUILD_DIR/../fred/gradlew"
   ## - tools/compare-gradle-jars-with-ant-jars
   ## - tools/compare-gradle-tests-with-ant-tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ dist: trusty
 # which speeds up the build.
 sudo: false
 
+env:
+  - FREENET_MINIMUM_JAVA_VERSION=7
+
 addons:
   apt:
     packages:
@@ -45,7 +48,7 @@ install:
   - git fetch && if [ "$(git rev-parse @)" != "$(git rev-parse @{u})" ] ; then FRED_UPDATED=1 ; git pull ; fi
   - cd "$TRAVIS_BUILD_DIR"
 
-# Compile Freenet Git repository
+# Compile Freenet Git repository, start a node
 before_script: |
   if [ "$FRED_UPDATED" = 1 ] ; then
     cd "$TRAVIS_BUILD_DIR"/../fred &&
@@ -79,6 +82,10 @@ before_script: |
   else
     echo "No changes at fred, not recompiling."
   fi
+  if [ "$TRAVIS_JDK_VERSION" = "openjdk$FREENET_MINIMUM_JAVA_VERSION" ] ; then
+    echo "Starting a Freenet node already to establish connectivity far before deploy stage..."
+    "$TRAVIS_BUILD_DIR"/.travis.start-freenet.sh
+  fi
 
 # Compile and test WoT
 script:
@@ -96,12 +103,12 @@ script:
   ## - tools/compare-gradle-tests-with-ant-tests
 
 jdk:
-  - oraclejdk9
-  - oraclejdk8
-  - openjdk10
-  - openjdk9
-  - openjdk8
   - openjdk7
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - oraclejdk8
+  - oraclejdk9
   # oraclejdk11: As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
   # openjdk11:   As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
   # oraclejdk10: Not supported anymore: https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612
@@ -114,3 +121,4 @@ deploy:
   script: ./.travis.upload-jar-to-freenet.sh
   on:
     all_branches: true
+    condition: $TRAVIS_JDK_VERSION = "openjdk$FREENET_MINIMUM_JAVA_VERSION"

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -291,7 +291,46 @@ CHANGELOG about stuff only interesting for developers
   FYI you can use e.g. jVisualVM to watch the memory usage and GC
   activity of Freenet.
 
-- Code quality: Travis CI: Test against most recent Java versions (xor)
+- 0006751: [Code quality] Provide a Gradle build script once fred does
+           (xor)
+
+  The most notable benefit is that the Gradle script executes unit tests
+  in parallel on all available CPU cores to greatly reduce their
+  runtime.
+  To reap immediate benefit of this, Travis CI has been changed to use
+  Gradle instead of Ant.
+  That may speed up the builds by up to 50% as Travis provides 2 CPU
+  cores.
+  It will ensure builds exceed the 50 minute timeout less frequently
+  - if at all anymore.
+
+  The new Gradle script has been based on fred's Gradle script as of
+  fred build 1481.
+  It has been trimmed from fred's 271 lines to 100 lines. This makes it
+  easy to understand and may allow it to serve as a template for other
+  Freenet plugins.
+
+  To ensure the script guarantees identical results as compared to the
+  original Ant build script, two further scripts were added:
+  - tools/compare-gradle-jars-with-ant-jars
+      Builds the WoT main and test JARs with both Ant and Gradle, unzips
+      them, and checks if the containing files match.
+  - tools/compare-gradle-tests-with-ant-tests
+      Checks if Ant and Gradle run the same set of unit tests.
+
+  These scripts have been executed once on Travis CI and they were
+  successful against all supported Java versions (see below).
+
+  The Ant build script has *not* been removed as it has more features
+  (most notably test coverage analysis).
+  I will continue maintaining both scripts until the Gradle one has the
+  same capabilities, and possibly beyond to provide developers with
+  freedom of choice.
+  Also having two different implementations of the same thing available
+  *and* tools to compare their results is a very sophisticated test,
+  which is a benefit of its own.
+
+- [Code quality] Travis CI: Test against most recent Java versions (xor)
 
   The cloud service now runs the unit tests periodically against:
   - oraclejdk9

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -345,6 +345,61 @@ CHANGELOG about stuff only interesting for developers
   Notably the new Java 11 is not tested yet due to Freenet's Gradle not
   working on it.
 
+- [Code quality] Travis CI: Speed up build time from 1 hour to
+                 20 minutes (xor)
+
+  Since build0020, the Travis CI build script has been uploading the
+  compiled WoT JAR directly to Freenet (as a CHK) from Travis CI.
+  The upload would start at the end of the build, and then take up to
+  half an hour, in addition to the time it took to run the build.
+
+  This has been improved by starting the Freenet node *before* the build
+  already.
+  As the build takes 10 minutes (was much more before the previous
+  optimization of using Gradle), the node has that time to establish
+  connectivity to the network before the upload is started at the end
+  of the build.
+  This greatly reduces the time of the upload because a well-connected
+  node will upload much more quickly I suppose.
+  A full "build, test and upload" cycle can now sometimes happen in as
+  little as ~ 20 minutes.
+
+  An important benefit of this is that builds should reach the 50 minute
+  time limit of Travis CI much less frequently now, if at all anymore.
+
+  Further, while previously the upload would happen on all Java versions
+  which Travis CI compiles for, currently 6 different ones, the upload
+  now only happens on the minimal Java version as required by Freenet
+  (currently Java 7).
+  This:
+  - ensures the resulting JAR will work on all Java versions
+  - cuts down our usage of Travis' free execution time
+  - further speeds up the time until a full build completes because
+    Travis only offers 5 parallel build jobs, but we compile for 6 Java
+    versions.
+    So previously the last job would have had to wait a long time for
+    one of the first ones to finish.
+
+  It has also been ensured that the Java 7 job, which takes the longest
+  due to the upload to Freenet, now is the first job which is started
+  in a build instead of the last one as it was previously.
+
+  Overall, including the previously shipped optimization of using Gradle
+  on Travis CI for parallel unit test execution, this yields the
+  following improvements (rough estimates) to the Travis build speed:
+  - Where compiling, testing and uploading a single WoT build, for all
+    Java versions, on Travis would previously finish after ~1 hour, it
+    now finishes in 20 min.
+    This means when a developer uploads new code to see if the tests
+    succeed they now only have to wait for 20 minutes for full
+    confirmation.
+  - Where the sum of Travis execution time for a single build, i.e.
+    sum of the time slots for the build jobs of all Java versions on
+    Travis, would previously be ~3 hours, it is now ~1 hour.
+    This isn't a direct benefit to Freenet developers, but a matter of
+    politeness towards Travis: They provide us with free computing
+    power, so we should try to not waste it.
+
 - 0006934: [Code quality] Replace "WithoutCommit" function name suffixes
            with "@NeedsTransaction" annotation (xor)
 

--- a/tools/benchmark-unit-tests
+++ b/tools/benchmark-unit-tests
@@ -16,6 +16,8 @@ fi
 ant clean &> /dev/null
 ant "${TESTCASE[@]}" -Dtest.coverage=false |
 	awk '
+		length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
 		/\[junit\] Running (.*)/ { testsuite=$3 }
-		/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+		/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = $5 " " $6 " " testsuite "." $3 "()" }
+		END { if(length(outbuf) > 0) { print outbuf } }' |
 	sort --numeric --key=1

--- a/tools/benchmark-unit-tests-from-travis
+++ b/tools/benchmark-unit-tests-from-travis
@@ -12,6 +12,8 @@ fi
 awk '/\$ ant/ {p=1} ; /BUILD SUCCESSFUL/ {p=3} ; p==2 {print $0} ; p==1 {p=2}' < "$1" |
 tr -d '\r' |
 awk '
+	length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
 	/\[junit\] Running (.*)/ { testsuite=$3 }
-	/\[junit\] Testcase: (.*) took (.*) sec/ { print $5,$6,testsuite "." $3 "()" }' |
+	/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = $5 " " $6 " " testsuite "." $3 "()" }
+	END { if(length(outbuf) > 0) { print outbuf } }' |
 sort --numeric --key=1

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -4,23 +4,25 @@ set -o errexit
 set -o errtrace
 trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
-from_ant="$(mktemp --directory --suffix=.from-ant)"
-from_gradle="$(mktemp --directory --suffix=.from-gradle)"
-trap 'rm -rf "$from_ant" "$from_gradle"' EXIT
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
 
-# FIXME: Also validate the unit test JAR
-jar='dist/WebOfTrust.jar'
+check_jar() {
+local jar="$1"
+local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"
+local from_gradle="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-gradle)"
 
+echo "Testing jar: $jar"
 echo "Building with Ant..."
 gradle clean &> /dev/null
-! [ -e "$jar" ]
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
 ant -Dtest.skip=true clean dist &> /dev/null
 unzip -qq "$jar" -d "$from_ant"
 
 echo "Building with Gradle..."
 ant clean &> /dev/null
-! [ -e "$jar" ]
-gradle clean jar &> /dev/null
+[ ! -e "$jar" ] # WARNING: ! must be inside for errexit to work here
+gradle clean jar testJar &> /dev/null
 unzip -qq "$jar" -d "$from_gradle"
 
 echo "Deleting files which only Ant bundles: package-info.class, Version.java (not .class)..."
@@ -40,11 +42,18 @@ sed --regexp-extended --expression='/^Ant(.*)$/d' \
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle/plugins/WebOfTrust/WebOfTrust.class"
 
-echo "Diffing..."
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
 if diff --recursive "$from_ant" "$from_gradle" ; then
 	echo "JARs are identical!"
-	exit 0
+	return 0
 else
-	echo "JARs do not match!" >&2
-	exit 1
+	echo "JARs do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	return 1
 fi
+}
+
+check_jar 'dist/WebOfTrust.jar'
+check_jar 'build-test/WebOfTrust-with-unit-tests.jar'

--- a/tools/compare-gradle-jars-with-ant-jars
+++ b/tools/compare-gradle-jars-with-ant-jars
@@ -7,6 +7,13 @@ trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 tmpdir="$(mktemp --directory)"
 trap 'rm -rf -- "$tmpdir"' EXIT
 
+if [ -e "./gradlew" ] ; then
+	echo "Found ./gradlew, using it instead of system's Gradle."
+	shopt -s expand_aliases
+	unalias -a
+	alias gradle=./gradlew
+fi
+
 check_jar() {
 local jar="$1"
 local from_ant="$(mktemp --tmpdir="$tmpdir" --directory --suffix=.from-ant)"

--- a/tools/compare-gradle-tests-with-ant-tests
+++ b/tools/compare-gradle-tests-with-ant-tests
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+tmpdir="$(mktemp --directory)"
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+from_ant="$(mktemp --tmpdir="$tmpdir" --suffix=.from-ant)"
+from_gradle="$(mktemp --tmpdir="$tmpdir" --suffix=.from-gradle)"
+
+echo "Testing with Ant..."
+gradle clean &> /dev/null
+ant -Dtest.skip=false clean dist |&
+	awk '
+		/\[junit\] Running (.*)/ { testsuite=$3 }
+		/\[junit\] Testcase: (.*) took (.*) sec/ { print testsuite "." $3 "()" }' |
+	sort > "$from_ant"
+
+echo "Testing with Gradle..."
+ant clean &> /dev/null
+gradle clean test |&
+	awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' |
+	sort > "$from_gradle"
+
+# To test whether the diff fails if it should:
+#echo a >> "$from_gradle"
+
+echo "Diffing:"
+echo "Ant output:    $from_ant"
+echo "Gradle output: $from_gradle"
+if diff "$from_ant" "$from_gradle" ; then
+	echo "Executed tests are identical!"
+	exit 0
+else
+	echo "Executed tests do not match! Not deleting output so you can inspect it." >&2
+	trap - EXIT
+	exit 1
+fi

--- a/tools/compare-gradle-tests-with-ant-tests
+++ b/tools/compare-gradle-tests-with-ant-tests
@@ -11,26 +11,44 @@ trap 'rm -rf -- "$tmpdir"' EXIT
 from_ant="$(mktemp --tmpdir="$tmpdir" --suffix=.from-ant)"
 from_gradle="$(mktemp --tmpdir="$tmpdir" --suffix=.from-gradle)"
 
-echo "Testing with Ant..."
-gradle clean &> /dev/null
-ant -Dtest.skip=false clean dist |&
-	awk '
-		/\[junit\] Running (.*)/ { testsuite=$3 }
-		/\[junit\] Testcase: (.*) took (.*) sec/ { print testsuite "." $3 "()" }' |
-	sort > "$from_ant"
+if [ -e "./gradlew" ] ; then
+	echo "Found ./gradlew, using it instead of system's Gradle."
+	shopt -s expand_aliases
+	unalias -a
+	alias gradle=./gradlew
+fi
 
-echo "Testing with Gradle..."
-ant clean &> /dev/null
-gradle clean test |&
-	awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' |
-	sort > "$from_gradle"
+echo "Cleaning Gradle output and testing with Ant..."
+gradle clean
+ant -Dtest.skip=false clean dist |& tee "${from_ant}.raw"
+awk '
+	length(outbuf) > 0 { if($0 !~ /SKIPPED/) { print outbuf } ; outbuf="" }
+	/\[junit\] Running (.*)/ { testsuite=$3 }
+	/\[junit\] Testcase: (.*) took (.*) sec/ { outbuf = testsuite "." $3 "()" }
+	END { if(length(outbuf) > 0) { print outbuf } }' \
+	"${from_ant}.raw" | sort > "$from_ant"
+
+echo "Cleaning Ant output and testing with Gradle..."
+ant clean
+gradle clean test |& tee "${from_gradle}.raw"
+awk '/^(.+) > (.+) PASSED$/ { print $1 "." $3 "()" }' \
+	"${from_gradle}.raw" | sort > "$from_gradle"
 
 # To test whether the diff fails if it should:
 #echo a >> "$from_gradle"
 
-echo "Diffing:"
+echo ""
 echo "Ant output:    $from_ant"
 echo "Gradle output: $from_gradle"
+
+ant_tests=$(wc -l "$from_ant" | cut -d' ' -f1)
+gradle_tests=$(wc -l "$from_gradle" | cut -d' ' -f1)
+[ "$ant_tests" -gt 0 ]
+[ "$gradle_tests" -gt 0 ]
+echo "Ant tests:     $ant_tests"
+echo "Gradle tests:  $gradle_tests"
+
+echo "Diffing:"
 if diff "$from_ant" "$from_gradle" ; then
 	echo "Executed tests are identical!"
 	exit 0


### PR DESCRIPTION
_This also contains the commits of the previous PR. Merge that first to only see the relevant diff here._
_As usual all PRs should be merged with `--ff-only` please._

----

**Notice:** `pyFreenet` fixes may help this become even faster.
To avoid asking you to go through the hassle of debugging my issues with it, can you please:
- ensure that pip3 ships the most recent version of pyFreenet? If [this](https://pypi.org/project/pyFreenet3/) is the website behind `pip3 install -U --user --egg pyFreenet3`, then **pip3's pyFreenet is still on 2017-06-27**.
Once you notice me it has been updated I will try if the issues actually still apply.
- tell me if the above pip3 command is actually the proper way to install it as the above website says otherwise? I think I obtained that command from your personal website.
- point me to the code of the latest version so I can see how to use it. I'm asking because it is not apparent from the pip3 website which Git repo/branch the code comes from, that's a potential improvement as well :)

----

Changelog in shipped modifications to `developer-documentation/changelogs/build0021.txt`.

Summary:
- start Freenet on Travis *before* the build so it is already well-connected once we use it to upload the JAR via pyFreenet. Cuts down the upload time from up to 30 to ~ 10 minutes.
- only upload the JAR on Java 7 = the minimal Java version fred requires.
- reduces usage of Travis computation resources from 3 hours to 1 hour per build.