### PR TITLE
IdentityFetcher-rewrite part 3: Wire-in new callback, implement other new callback

### DIFF
--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -2782,6 +2782,14 @@ public final class WebOfTrust extends WebOfTrustInterface
 			if(logDEBUG) Logger.debug(this, "Deleting received scores...");
 			for(Score score : getScores(identity)) {
 				score.deleteWithoutCommit();
+				// FIXME: The Score object won't be able to loads its members from the database
+				// at this point because we just deleted it so we should clone() it before
+				// deleteWithoutCommit() and then pass the clone to SubscriptionManager. This
+				// won't need database upgrade code to repair old databases because the
+				// mSubscriptionManager database is currently deleted at every restart (but that
+				// will change soon due to https://freenet.mantishub.io/view.php?id=6113).
+				// This also applies to all other mSubscriptionManager callbacks in this
+				// function.
 				mSubscriptionManager.storeScoreChangedNotificationWithoutCommit(score, null);
 			}
 

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -2761,6 +2761,8 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 *   However, the implementations of those functions might cause leaks by forgetting to delete certain object members.
 	 *   If you call this function for ALL identities in a database, EVERYTHING should be deleted and the database SHOULD be empty.
 	 *   You then can check whether the database actually IS empty to test for leakage.
+	 * - In the future it may be used as a foundation for code for garbage collection of Identitys.
+	 *   See https://bugs.freenetproject.org/view.php?id=2509
 	 * 
 	 * You have to lock the WebOfTrust, the IntroductionPuzzleStore, the IdentityFetcher, the
 	 * SubscriptionManager and the Persistent.transactionLock() before calling this function.
@@ -2821,9 +2823,10 @@ public final class WebOfTrust extends WebOfTrustInterface
 			if(logDEBUG) Logger.debug(this, "Deleting given trusts...");
 			for(Trust givenTrust : getGivenTrusts(identity)) {
 				givenTrusts.add(givenTrust.clone());
+				// We call computeAllScoresWithoutCommit() by finishTrustListImport() so we do not
+				// have to use removeTrustWithoutCommit() to compute Score changes individually
 				givenTrust.deleteWithoutCommit();
 				mSubscriptionManager.storeTrustChangedNotificationWithoutCommit(givenTrust, null);
-				// We call computeAllScores anyway so we do not use removeTrustWithoutCommit()
 			}
 			
 			mFullScoreComputationNeeded = true; // finishTrustListImport will call computeAllScoresWithoutCommit for us.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -84,8 +84,16 @@ public interface IdentityDownloader extends Daemon {
 	 * deleting an {@link OwnIdentity}.
 	 * 
 	 * After the callback returns the oldIdentity will be deleted from the database.
-	 * Any {@link Score}s it has given to other {@link Identity}s as specified by
+	 * It will be replaced by a non-own {@link Identity} object. Its given and received
+	 * {@link Trust}s, and its received {@link Score}s will keep existing by being replaced with
+	 * objects which to point to the replacement Identity.
+	 * Any Scores the oldIdentity has given to other Identitys as specified by
 	 * {@link WebOfTrust#getGivenScores(OwnIdentity)} will be deleted then.
+	 * 
+	 * After this callback has returned, and once the replacement Identity has been created and the
+	 * {@link Trust} and Score database fully adapted to it, WoT will call
+	 * {@link #storePostDeleteOwnIdentityCommand(Identity)} in order to allow implementations to
+	 * start download of the replacement Identity if it is eligible for download.
 	 * 
 	 * Thus implementations have to:
 	 * - remove any object references to the oldIdentity object from the db4o database as they
@@ -105,13 +113,7 @@ public interface IdentityDownloader extends Daemon {
 	 * Implementations can assume that when this function is called:
 	 * - the OwnIdentity still is stored in the database, the replacement Identity object has not
 	 *   been created yet.
-	 * - the Score database has not been changed yet.
-	 * I.e. they can assume that nothing has changed about the OwnIdentity or any other aspect
-	 * related to it yet.
-	 * 
-	 * After this callback has returned, and once the replacement Identity has been created and the
-	 * {@link Trust} and Score database fully adapted to it, WoT will call
-	 * {@link #storePostDeleteOwnIdentityCommand(Identity)}. */
+	 * - the Trust and Score database has not been changed yet. */
 	@NeedsTransaction void storePreDeleteOwnIdentityCommand(OwnIdentity oldIdentity);
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -23,15 +23,20 @@ import freenet.keys.FreenetURI;
  * They are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which is consumed by
  * the {@link IdentityFileProcessor}.
  * 
+ * Implementations are allowed to and do store pointers to {@link Identity} and {@link OwnIdentity}
+ * objects in their database, currently as part of {@link EditionHint} objects.
+ * They must not store references to any other objects which are not a type managed by their own
+ * database, e.g. {@link Trust} or {@link Score} (because this interface only has callbacks for
+ * changes to Identity objects).
  * FIXME: 
- * Implementations are allowed to and do store pointers to Identity objects in their database,
- * currently as part of {@link EditionHint} objects.
  * Thus we must introduce a new callback which gets called before deletion of an Identity to ensure
  * the IdentityDownloader implementations delete the objects pointing to the to-be-deleted Identity.
  * Further at least the following functions must be amended to call the new callback:
  * - {@link WebOfTrust#deleteWithoutCommit(Identity)}
  * - {@link WebOfTrust#deleteOwnIdentity(String)}
  * - {@link WebOfTrust#restoreOwnIdentityWithoutCommit(freenet.keys.FreenetURI)}
+ * EDIT: This is being resolved by the five new callbacks at the beginning of the interface, it can
+ * be removed once they're done (as specified by the FIXMEs there).
  * 
  * <b>Locking:</b>
  * Implementations  must synchronize transactions by taking the following locks in the given order:

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -139,6 +139,13 @@ public interface IdentityDownloader extends Daemon {
 	 * - {@link WebOfTrust#getGivenScores(OwnIdentity)} if the Identity was an {@link OwnIdentity}.
 	 * - {@link WebOfTrust#getScores(Identity)}
 	 * 
+	 * After this callback has returned, in opposite to the other callbacks of this interface, no
+	 * such callback as "storePostDeleteIdentityCommand()" will be called. This is because:
+	 * - there will be no replacement Identity to pass by a callback.
+	 * - deletion of an Identity can only cause abortion of downloads, not starting - which would
+	 *   typically be the job of a Post-deletion version of this callback with starting the download
+	 *   of the replacement Identity if necessary, but there will be none.
+	 * 
 	 * Thus implementations have to:
 	 * - remove any object references to the oldIdentity object from the db4o database as they
 	 *   would otherwise be nulled by the upcoming deletion of it.
@@ -155,16 +162,7 @@ public interface IdentityDownloader extends Daemon {
 	 * 
 	 * Implementations can assume that when this function is called:
 	 * - the Identity still is stored in the database.
-	 * - the Trust and Score database has not been changed yet.
-	 * I.e. they can assume that nothing has changed about the Identity or any other aspect related
-	 * to it yet.
-	 * 
-	 * After this callback has returned, in opposite to the other callbacks of this interface, no
-	 * such callback as "storePostDeleteIdentityCommand()" will be called. This is because:
-	 * - there will be no replacement object for the deleted Identity
-	 * - deletion of an Identity can only cause aborting of downloads, not starting - which would
-	 *   typically be the job of a Post-deletion version of this callback with starting the download
-	 *   of the replacement Identity if necessary. */
+	 * - the Trust and Score database has not been changed yet. */
 	@NeedsTransaction void storePreDeleteIdentityCommand(Identity oldIdentity);
 
 	// There is no replacement Identity when a non-own Identity is deleted.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -551,7 +551,6 @@ public final class IdentityDownloaderFast implements
 		// for the purpose of WebOfTrust.restoreOwnIdentity(). Thus we new to abort a potentially
 		// pre-existing download.
 		storeAbortFetchCommandWithoutCommit_Checked(oldIdentity);
-
 	}
 
 	@Override public void storePostDeleteOwnIdentityCommand(Identity newIdentity) {

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -560,6 +560,15 @@ public final class IdentityDownloaderFast implements
 			storeStartFetchCommandWithoutCommit_Checked(newIdentity);
 	}
 
+	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
+		if(oldIdentity instanceof OwnIdentity)
+			storePreDeleteOwnIdentityCommand((OwnIdentity)oldIdentity);
+		else {
+			if(shouldDownload(oldIdentity))
+				storeAbortFetchCommandWithoutCommit_Checked(oldIdentity);
+		}
+	}
+
 	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
 			OwnIdentity newIdentity) {
 		


### PR DESCRIPTION
_Please merge this into branch `issue-0003816-IdentityFetcher-rewrite` with `--ff-only`._
_This also contains the commits of the previous PRs to that branch. Merge those first to only see the relevant diff here._

---

WebOfTrust.deleteWihtoutCommit(Identity): Wire in new IdentityDownloader
callback storePreDeleteIdentityCommand()

IdentityDownloaderFast: Implement storePreDeleteIdentityCommand()