### PR TITLE
IdentityFetcher-rewrite part 12: Remove obsolete callbacks; documentation

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="db4o-7.4/db4o.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fred"/>
 	<classpathentry kind="lib" path="/fred/lib/freenet/freenet-ext.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit4.jar"/>

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "db4o-7.4"]
+	path = db4o-7.4
+	url = https://github.com/xor-freenet/db4o-7.4.git

--- a/.travis.upload-jar-to-freenet.sh
+++ b/.travis.upload-jar-to-freenet.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o errtrace
+trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
+
+FILENAME="WebOfTrust-$(git describe)-built-on-$TRAVIS_JDK_VERSION.jar"
+URI="CHK@/$FILENAME"
+
+echo "Installing pyFreenet3..."
+pip3 install -U --user --egg pyFreenet3
+
+# FIXME: As of 2018-05-03 fcpupload's "--spawn" parameter doesn't work,
+# see https://bugs.freenetproject.org/view.php?id=7018 - so we start our
+# own node.
+# Once that is fixed don't start a node here - do so by reverting the
+# commit which added this FIXME.
+
+cd "$TRAVIS_BUILD_DIR"/../fred
+echo "Configuring node..."
+
+# FIXME: Use fred's official URL once there is one
+wget https://github.com/ArneBab/lib-pyFreenet-staging/releases/download/spawn-ext-data/seednodes.fref
+
+cat << EOF > freenet.ini
+node.updater.enabled=false
+node.clientCacheType=ram
+node.storeType=ram
+fproxy.hasCompletedWizard=true
+security-levels.physicalThreatLevel=LOW
+security-levels.networkThreatLevel=LOW
+node.opennet.enabled=true
+node.outputBandwidthLimit=1048576
+node.inputBandwidthLimit=-1
+node.opennet.maxOpennetPeers=65
+node.load.threadLimit=1000
+logger.priority=NONE
+End
+EOF
+
+echo "Starting node..."
+java -Xmx512M -classpath 'build/output/*' -Djna.nosys=true freenet.node.NodeStarter &
+cd "$TRAVIS_BUILD_DIR"
+
+echo "Giving node 60s to boot..."
+sleep 60s
+
+echo "Uploading WoT JAR to $URI..."
+
+# Echo something every minute to prevent Travis from killing the job
+# after 10 minutes of silence.
+(
+	minutes=0
+	while sleep 1m ; do
+		echo Minutes passed: $((++minutes))
+	done
+) &
+
+# TODO: As of 2018-05-30 fcpupload's "--timeout" doesn't work, using coreutils' timeout, try again later
+# TODO: As of 2018-05-30 fcpupload's "--compress" also doesn't work.
+if ! time timeout 30m fcpupload --wait "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+	echo "Uploading WebOfTrust.jar to Freenet failed!" >&2
+	
+	# The commented out lines are for debugging fcpupload's "--spawn".
+	#
+	# echo "Uploading WebOfTrust.jar to Freenet failed! Dumping wrapper.log, wrapper.conf and listing node dir..." >&2
+	# echo "wrapper.log:" >&2
+	# cat "$HOME/.local/share/babcom-spawn-9486/wrapper.log" >&2
+	# echo "wrapper.conf:" >&2
+	# cat "$HOME/.local/share/babcom-spawn-9486/wrapper.conf" >&2
+	# echo "Node dir:" >&2
+	# ls -alR "$HOME/.local/share/babcom-spawn-9486/" >&2
+	
+	exit 1
+fi
+
+# Can't use "kill $(jobs -p)" as that fails if a job exits in between
+jobs -p | xargs --no-run-if-empty kill || true
+
+if ! wait ; then
+	echo "Node exit code indicates error!" >&2
+	exit 1
+fi
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ branches:
 language: java
 
 # We need Ubuntu 14.04 due to very new JUnit API which WoT needs
-sudo: required
 dist: trusty
+# Disabling sudo routes the build to a Docker container instead of a VM
+# which speeds up the build.
+sudo: false
 
 addons:
   apt:
@@ -16,7 +18,11 @@ addons:
     - ant-optional
     - junit4
     - libhamcrest-java
+    # For .travis.upload-jar-to-freenet.sh
+    - python3-pip
   # TODO: Code quality: Remove this workaround for https://github.com/travis-ci/travis-ci/issues/5227
+  hosts:
+    - freenet-plugin-WebOfTrust
   hostname: freenet-plugin-WebOfTrust
 
 before_cache:
@@ -37,28 +43,32 @@ before_install:
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred ; else cd fred ; git pull ; cd .. ; fi
   - cd fred
   - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
-  # TODO: Code quality: Do we also need to do "gradle clean" or is
-  # Gradle smart enough to notice if Git changed things? I suppose it
-  # is?
-  - gradle jar -x test
-  # Create symlink to JARs in the places where they used to be with the old
-  # Ant builder so WoT finds them.
-  - if [ ! -e dist/freenet.jar ]; then mkdir -p dist && cd dist && ln -s ../build/libs/freenet.jar && cd .. ; fi
-  # TODO: Code quality: How to obtain these paths in a clean way without hardcoding them?
-  - if [ ! -e lib/bcprov.jar ]; then mkdir -p lib && cd lib && ln -s $HOME/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcprov-jdk15on/1.57/*/bcprov-jdk15on-1.57.jar bcprov.jar && cd .. ; fi
-  - if [ ! -e lib/freenet/freenet-ext.jar ]; then mkdir -p lib/freenet && cd lib/freenet && ln -s $HOME/.gradle/caches/modules-2/files-2.1/org.freenetproject/freenet-ext/29/*/freenet-ext-29.jar freenet-ext.jar && cd ../.. ; fi
-  - if [ ! -e lib/jna.jar ]; then mkdir -p lib && cd lib && ln -s $HOME/.gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna/4.2.2/*/jna-4.2.2.jar jna.jar && cd .. ; fi
+  # The gradlew binary which fred ships doesn't work on OpenJDK 7, need to use Travis' gradle there.
+  - if [ "$TRAVIS_JDK_VERSION" = "openjdk7" ] ; then rm ./gradlew && ln -s "$(which gradle)" ./gradlew ; fi
+  # TODO: freenet.jar won't contain class Version if we don't run the
+  # clean task in a separate execution of Gradle. Why?
+  - ./gradlew clean
+  # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
+  # needs - to build/output/
+  - ./gradlew jar copyRuntimeLibs -x test
   - cd "$TRAVIS_BUILD_DIR"
   # Print the checksums of the WoT dependencies - for debugging
-  - sha256sum ../fred/dist/freenet.jar
-  - sha256sum ../fred/lib/freenet/freenet-ext.jar
-  - sha256sum ../fred/lib/bcprov.jar
-  - sha256sum ../fred/lib/jna.jar
+  - sha256sum ../fred/build/output/*
 
 script: ant
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
-  # Not supported anymore I guess: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
-  # - oraclejdk7
+  - openjdk8
   - openjdk7
+  # openjdk9: As of 2018-05-12 isn't available on Travis yet.
+  # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+
+deploy:
+  provider: script
+  # Prevent Travis from deleting the JAR before we can deploy it (wtf?)
+  skip_cleanup: true
+  script: ./.travis.upload-jar-to-freenet.sh
+  on:
+    all_branches: true

--- a/build.xml
+++ b/build.xml
@@ -2,16 +2,47 @@
 <!-- ant build file for WoT -->
 
 <project name="WoT" default="dist" basedir="." xmlns:if="ant:if" xmlns:unless="ant:unless">
+	<!-- ======================================================================================= -->
+	<!-- Configuration                                                                           -->
+	<!-- ======================================================================================= -->
+		
+	<!-- You can use this file to override the below properties. -->
 	<property file="override.properties"/>
-
-	<property name="freenet-cvs-snapshot.location" location="../fred/dist/freenet.jar"/>
-	<property name="freenet-ext.location" location="../fred/lib/freenet/freenet-ext.jar"/>
-	<property name="bcprov.location" location="../fred/lib/bcprov.jar"/>
-	<property name="jna.location" location="../fred/lib/jna.jar"/>
+	<!-- Dependencies. These are the most important to configure!                               -->
+	<!--                                                                                        -->
+	<!-- Freenet build01481 compiled with "./gradlew jar copyRuntimeLibs" will copy the         -->
+	<!-- freenet.jar and its dependencies to this directory:                                    -->
+	<property name="freenet.lib.new.location"   location="../fred/build/output/"/>
+	<!-- Older Freenet builds will use these places for the JARs, some of which have to be      -->
+	<!-- downloaded manually:                                                                   -->
+	<property name="freenet.lib.old.location.1" location="../fred/lib/bcprov.jar"/>
+	<property name="freenet.lib.old.location.2" location="../fred/lib/jna-platform.jar"/>
+	<property name="freenet.lib.old.location.3" location="../fred/lib/jna.jar"/>
+	<property name="freenet.lib.old.location.4" location="../fred/lib/freenet/freenet-ext.jar"/>
+	<property name="freenet.lib.old.location.5" location="../fred/dist/freenet.jar"/>
+	<!-- Unit test dependencies                                                                 -->
+	<property name="junit.location" value="/usr/share/java/junit4.jar"/>
+	<property name="hamcrest.location" value="/usr/share/java/hamcrest-core.jar"/>
+	<!-- Optional, only needed if using "ant -Dtest.coverage=true"                              -->
+	<property name="cobertura.location" value="/usr/share/java/cobertura.jar"/>
+	<!-- Minimum Java version which fred officially requires
+	   = Maximum version which WoT's code can use features of. -->
+	<property name="source-version" value="7"/>
+	<property name="target-version" value="7"/>
+	<!-- To allow you to restart your debug node after recompiling without manually reloading
+	     the WoT plugin you can specifiy this property to point to the node's WebOfTrust.jar.
+	     The Ant builder will delete it automatically as part of the "clean" target. -->
 	<property name="debug-node-wot-plugin.location" location="../fred/plugins/WebOfTrust.jar"/>
+	
+	<!-- ======================================================================================= -->
+	<!-- Configuration which you should probably leave as is!                                    -->
+	<!-- ======================================================================================= -->
+	
+	<!-- Git submodule directory of the db4o source code. Will be compiled automatically! -->
+	<property name="db4o-submodule.location" location="db4o-7.4"/>
+	<!-- JAR which the Ant builder of db4o produces. -->
+	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
 	<property name="svn.revision" value="@custom@"/>
-	<property name="source-version" value="1.7"/>
-	<property name="target-version" value="1.7"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
 	<property name="build-test-jar" location="${build-test}/WebOfTrust-with-unit-tests.jar"/>
@@ -19,9 +50,6 @@
 	<property name="dist" location="dist/"/>
 	<property name="src" location="src/"/>
 	<property name="javadoc" location="javadoc/"/>
-	<property name="junit.location" value="/usr/share/java/junit4.jar"/>
-	<property name="hamcrest.location" value="/usr/share/java/hamcrest-core.jar"/>
-	<property name="cobertura.location" value="/usr/share/java/cobertura.jar"/>
 	<property name="version.src" value="plugins/WebOfTrust/Version.java" />
 	<property name="version.build" value="plugins/WebOfTrust/Version.class" />
 
@@ -31,15 +59,40 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
+	<!-- Libraries whose classes are to be bundled in our own JAR. -->
+	<path id="submodules.path">
+		<pathelement location="${db4o.location}"/>
+	</path>
+	<!-- Libraries which we get from fred. -->
 	<path id="lib.path">
-		<pathelement location="${bcprov.location}"/>
-		<pathelement location="${jna.location}"/>
-		<pathelement location="${freenet-ext.location}"/>
-		<pathelement location="${freenet-cvs-snapshot.location}"/>
+		<!-- Use filesets instead of <pathelement> to:
+		     - allow using wildcards when including freenet.lib.new.location so we don't need to
+		       synchronize the list of JARs which fred needs with what this build file includes.
+		     - for the old JAR locations ensure the print-libs task won't print files which don't
+		       exist as that is what he wildcard usage dictates for thew new location already. -->
+		
+		<fileset dir="${freenet.lib.new.location}" erroronmissingdir="no" casesensitive="no">
+			<include name="**/*.jar"/>
+		</fileset>
+		<fileset file="${freenet.lib.old.location.1}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.2}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.3}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.4}" erroronmissingdir="no"/>
+		<fileset file="${freenet.lib.old.location.5}" erroronmissingdir="no"/>
 	</path>
 
 	<path id="cobertura.path">
 		<pathelement location="${cobertura.location}"/>
+	</path>
+	
+	<!-- For print-libs task: All runtime dependencies of WoT plus the build-time dependencies.
+	     Uses <fileset> instead of <pathelement> so it only contains only those which exist as that
+	     is what lib.path does already. -->
+	<path id="lib.external.all.path">
+		<path refid="lib.path"/>
+		<fileset file="${junit.location}" />
+		<fileset file="${hamcrest.location}"/>
+		<fileset file="${cobertura.location}"/>
 	</path>
 
 	<presetdef name="javac">
@@ -75,21 +128,53 @@
 		</and>
 	</condition>
 
+	<target name="get-submodules" description="Downloads the git submodules required by WoT">
+		<echo>Downloading db4o git submodule if it doesn't exist already...</echo>
+		<exec executable="git">
+			<arg line="submodule update --init"/>
+		</exec>
+	</target>
+
+	<target name="db4o" depends="get-submodules" description="Compiles the database submodule">
+		<echo>Compiling db4o submodule...</echo>
+		<ant dir="${db4o-submodule.location}" inheritAll="false" useNativeBasedir="true">
+			<property name="javac.source.version" value="${source-version}"/>
+			<property name="javac.target.version" value="${target-version}"/>
+		</ant>
+	</target>
+
+	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
+		<echo>Cleaning db4o submodule...</echo>
+		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
+			useNativeBasedir="true"/>
+	</target>
+
+
+	<target name="print-libs">
+		<echo>External dependencies on classpath follow, but ONLY those which did exist.</echo>
+		<echo>(This cannot tell which JARs are missing because that would require ant-contrib</echo>
+		<echo>and I don't want to require Freenet release managers to install it. Sorry.)</echo>
+		<echo></echo>
+		<echo>If compiling fails due to missing classes please:</echo>
+		<echo>- ensure fred was built with "./gradlew jar copyRuntimeLibs" to make it copy</echo>
+		<echo>  its dependencies' JARs to "build/output/".</echo>
+		<echo>- compare the found JARs against the configuration at top of build.xml to find</echo>
+		<echo>  out which JARs are missing.</echo>
+		<echo></echo>
+		<pathconvert refid="lib.external.all.path" pathsep="${line.separator}" property="all.path.printable"/>
+		<echo>${all.path.printable}</echo>
+	</target>
+
 	<target name="mkdir">
 		<mkdir dir="${build}"/>
 		<mkdir dir="${build-test}"/>
 		<mkdir dir="${build-test}/test"/>
 		<mkdir dir="${build-test-coverage}"/>
 		<mkdir dir="${dist}"/>
-		<echo message="Using ${freenet-cvs-snapshot.location} as freenet-cvs-snapshot.jar"/>
-		<echo message="Using ${freenet-ext.location} as freenet-ext.jar"/>
-		<echo message="Using ${bcprov.location} as bcprov.jar"/>
-		<echo message="Using ${jna.location} as jna.jar"/>
-		<echo message="Using ${cobertura.location} as cobertura.jar"/>
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="mkdir" >
+	<target name="compile" depends="print-libs, db4o, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -104,6 +189,7 @@
 		<!-- Force compile of Version.java in case compile of ${src} didn't trigger it -->
 		<javac srcdir="${build}" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}">
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 			</classpath>
 			<include name="${version.src}"/>
@@ -112,6 +198,7 @@
 		<!-- FIXME: remove the debug and replace with optimize -->
 		<javac srcdir="src/" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}" encoding="UTF-8">
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 			</classpath>
 			<include name="**/*.java"/>
@@ -138,6 +225,7 @@
 				source="${source-version}" target="${target-version}" >
 			
 			<classpath>
+				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
 				<pathelement path="${build}"/>
 				<pathelement location="${junit.location}"/>
@@ -181,6 +269,9 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
+			<zipfileset>
+				<path refid="submodules.path"/>
+			</zipfileset>
 		</jar>
 	</target>
 
@@ -238,6 +329,7 @@
 						unless="test.unreliable" />
 					<exclude name="**/TickerDelayedBackgroundJobTest.class"
 						unless="test.unreliable" />
+					<exclude name="com/db4o/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -276,6 +368,7 @@
 					     JUnit would then complain that those classes do not contain a public
 					     constructor. -->
 					<exclude name="**/*$*.class"/>
+					<exclude name="com/db4o/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -298,27 +391,34 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
+			<zipfileset>
+				<path refid="submodules.path"/>
+			</zipfileset>
 		</jar>
 	</target>
 
 	<!-- ================================================== -->
 	<target name="javadoc" description="generate javadocs">
 		<delete dir="${javadoc}"/>
-		<javadoc classpathref="lib.path" destdir="${javadoc}" author="true" version="true" use="true" private="true">
+		<path id="javadoc.classpath">
+			<path refid="submodules.path"/>
+			<path refid="lib.path"/>
+		</path>
+		<javadoc classpathref="javadoc.classpath" destdir="${javadoc}" author="true" version="true" use="true" private="true">
 			<fileset dir="src/" defaultexcludes="yes">
 				<include name="**/*.java"/>
 			</fileset>
-			<link href="http://docs.oracle.com/javase/6/docs/api/"/>
+			<link href="http://docs.oracle.com/javase/${source-version}/docs/api/"/>
 			<link href="http://freenetproject.org/javadocs/"/>
 		</javadoc>
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-db4o" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>
 		<delete dir="${dist}"/>
-		<delete file="${debug-node-WebOfTrust-plugin.location}"/>
+		<delete file="${debug-node-wot-plugin.location}"/>
 	</target>
 </project>

--- a/developer-documentation/Changelog-template.txt
+++ b/developer-documentation/Changelog-template.txt
@@ -1,14 +1,16 @@
 Web of Trust Version 0.4.4 build0018
 ------------------------------------------------------------------------
 
-SUMMARY AND OUTLOOK (detailed changelog is below):
+SUMMARY AND OUTLOOK (detailed changelog is below)
 
 Summary blah blah. Blah blah reference to link [1].
 
 Outlook blah blah.
 
+FIXME: Add "TESTING" / "DOWNLOAD" sections from build0020.txt
+Also add that to build0021.txt
 
-CHANGELOG - prefixed with the bugtracker issue number:
+CHANGELOG - prefixed with the bugtracker issue number
 
 - 0000001: [category_of_issue_1] title_of_issue_1.......................
            more_lines_of_title (developer_of_issue_1)...................
@@ -24,8 +26,7 @@ CHANGELOG - prefixed with the bugtracker issue number:
   Blah.
   Blah.
 
-
-CHANGELOG about stuff only interesting for developers:
+CHANGELOG about stuff only interesting for developers
 
 - 0000004: .............................................................
            .............................................................
@@ -33,11 +34,7 @@ CHANGELOG about stuff only interesting for developers:
   Blah.
   Blah.
 
+THANKS TO
 
-Thanks to:
   - Person1
   - Person2
-
-
-Links:
-  [1] https://...

--- a/developer-documentation/changelogs/build0020.txt
+++ b/developer-documentation/changelogs/build0020.txt
@@ -1,0 +1,217 @@
+Web of Trust Version 0.4.5 build0020
+------------------------------------------------------------------------
+
+SUMMARY (detailed changelog is below)
+
+This is an intermediate maintenance build which caters mostly to
+developers, testers and paranoid users.
+Especially Freenet core developers shall benefit from its two primary
+goals:
+
+1) It prepares WoT for the removal of the library freenet-ext.jar and
+   its contained db4o library from Freenet.
+   It does so by bundling db4o inside WoT's JAR and making WoT
+   independent from the naming of the JARs which Freenet depends on.
+
+2) The cloud service Travis CI, which was previously only used for
+   running WoT unit tests, now automatically uploads the resulting
+   WoT binary to Freenet after it has compiled and tested it.
+
+Users and testers can also benefit from aspect 2 by using it to have an
+independent service validate that the published WoT binary matches the
+source code, see the below full changelog at issue 0007018.
+
+The bundling of db4o should in theory work on existing Freenet
+installations where db4o is both contained in Freenet and in WoT - but
+it would be nice to have some confirmation from testers that this does
+indeed work on various operating systems and Java versions.
+So feedback on whether it works on your installation would be
+appreciated.
+
+TESTING
+
+Make sure to backup the WebOfTrust directory (located in the directory
+Freenet is installed to) before you use this!
+
+Easy high level testing:
+- Check the Community / Statistics page for unusual stuff. E.g.:
+  - Data loss, e.g. decreasing count of own identities, non-own
+    identities or trust values as compared to your database before
+    installation of the testing version.
+  - High count of "Failed files" at the Identity file queue / Identity
+    file processor section.
+  - No significant progress in average downloaded / queued / processed
+    identity XML files  even after a day of uptime.
+
+Tedious low level testing:
+- Check "freenet-latest.log" for ERRORs of plugins.WebOfTrust.*
+  You can filter for this by configuring logging as:
+  - Set "Minimum priority to log messages at" to "NONE".
+  - Set "Detailed priority thresholds" to "plugins.WebOfTrust:ERROR".
+    Now any logging except WoT errors is disabled.
+  Besides you should probably increase "Log rotation interval" to
+  "48HOUR" (yes, no S in HOUR), the default is very low, 1 hour IIRC.
+  Before you report anything from the log file make VERY sure to review
+  it for private data! It might even contain the secret insert URIs of
+  your identities!
+
+DOWNLOAD
+
+Until it has been shipped with a Freenet release this build is available
+using "WebOfTrust Testing Versions" at "Configuration / Plugins" of a
+standard Freenet node.
+You need to unload the regular WoT first!
+
+CHANGELOG - prefixed with the bugtracker issue number
+
+- 0007018: [Code quality] Travis CI: Upload WebOfTrust.jar to Freenet
+           using pyFreenet (xor)
+
+  Travis CI is a cloud service which allows us to automatically compile
+  WoT from the source code and run the unit tests.
+
+  WoT's Travis script has been amended to spawn a Freenet node and
+  upload the compiled WoT binary to Freenet.
+  This can be a great stress reduction for release managers as the trust
+  they need to put into the security of their machine is greatly reduced
+  if they can choose to build the binaries elsewhere.
+  The overall security of that might be a bit better because Travis is a
+  large, widely used service and thereby they have more resources at
+  hand to ensure a secure infrastructure.
+  Further users can use it as a third-party verification that we didn't
+  put secret code into the binaries before we uploaded them (see below).
+
+  To obtain the Freenet URI of an uploaded WoT JAR search the raw Travis
+  job log for "CHK@". Jobs are at:
+    https://travis-ci.org/xor-freenet/plugin-WebOfTrust/builds
+    https://travis-ci.org/freenet/plugin-WebOfTrust/builds
+  For every build there are usually different jobs for various Java
+  versions. For WoT testing releases I will be using the CHK as compiled
+  by OpenJDK in the version which is the minimal requirement of Freenet
+  at time of the release. For this WoT release that is OpenJDK 7.
+
+  The JAR will only be uploaded if compiling and testing did succeed,
+  otherwise there will be no CHK@ in the output.
+
+  If Freenet release managers choose to use Travis CI for compiling then
+  the CHK@ URI which they put into fred will match what Travis CI has
+  published in the build job for the git tag build0020 (= commit
+  "Version 0.4.5 build0020") of this release.
+  As the CHK contains a strong hash of the file it being identical
+  proves that it indeed serves the same file as Travis CI produced.
+  Once testing of this build is finished and it has been released as
+  part of a regular Freenet release you can check the CHK@ in the
+  following file of the fred repository:
+    src/freenet/pluginmanager/OfficialPlugins.java
+  which is hosted at
+    https://git.io/vhcsV
+
+  While this release is still in testing verification works differently
+  because the testing URI is an USK:
+  Download the Travis CHK and the testing USK (listed in the above
+  file) and compare a checksum of the resulting file, e.g. with the
+  sha256sum command.
+
+- 0006737: [Code quality] Prepare for fred's removal of freenet-ext.jar
+           and db4o
+
+  Freenet build01482 is scheduled to split up freenet-ext.jar into
+  multiple JARs, and during this procedure remove db4o from the set of
+  JARs which Freenet ships.
+
+  To prepare for that, the following has been done:
+
+  - the WoT build script has been amended to bundle db4o in WoT's own
+    JAR. To achieve that a db4o-7.4 repository has been extracted from
+    the Freenet "contrib" repository.
+    WoT's build script has been amended to automatically clone that git
+    repository and compile db4o locally.
+    To ensure the least possible effort is required by Freenet release
+    managers in validating that these db4o binaries match what had been
+    deployed as part of freenet-ext previously, the following steps were
+    taken:
+      - the db4o-7.4 repository is pulled by the build script using a
+        "git submodule" which ensures that the specific commit which is
+        pulled is hardcoded into the WoT repository and can only be
+        changed manually by whoever has push access to the WoT
+        repository hosted by Freenet.
+        This means that I can host the db4o-7.4 repository on my own
+        GitHub account (xor-freenet) WITHOUT being able to change what
+        people get when they pull WoT from Freenet's GitHub.
+        In turn Freenet does not have to host a clone of the db4o
+        repository on their own.
+      - the db4o-7.4 repository was extracted from Freenet's contrib
+        repository, not from the original db4o SVN. This allows Freenet
+        release managers to simply use:
+          $ git verify-tag v29
+          $ gitk v29..HEAD
+        to see what has changed between the deployed freenet-ext and
+        the new db4o-7.4 repository.
+        Keeping the db4o version which WoT uses as close to what it has
+        been using previously is critically important because my test
+        runs have shown that newer db4o versions trigger severe bugs.
+        That is also why the repository is called "db4o-7.4" instead of
+        just "db4o" - to document that WoT currently needs precisely that
+        version.
+        Once I am ready to deal with fixing the bugs triggered by newer
+        versions I will publish the original db4o SVN repository as a
+        git repository called "db4o" and switch WoT to use that. So the
+        db4o commit history is not lost yet :)
+
+  - WoT's build script has been changed to not hardcode any specific
+    filenames of JARs which fred and thereby WoT needs as dependencies.
+    Instead all JARs in the directory
+      ../fred/build/output/
+    are included on the classpath when building WoT. That directory is
+    populated if fred is built with:
+      $ ./gradlew jar copyRuntimeLibs
+    To allow you to test whether the WoT builder finds all JARs a new
+    Ant task was introduced:
+      $ ant print-libs
+    It should show all runtime dependencies of fred (see its Gradle
+    build file), plus "junit4.jar", "hamcrest-core.jar" and
+    optionally "cobertura.jar" if using "ant -Dtest.coverage=true".
+    (The db4o JAR won't be shown as that is not an external dependency,
+    i.e. WoT obtains it automatically, you don't have to provide it.)
+    If compiling fails due to missing classes see the "Configuration"
+    section at top of "build.xml" for the configured locations - all
+    external JARs have been moved to that section.
+
+- 0006929: [Bugs] Travis CI builds fail due to changes at fred (xor)
+
+  The .travis.yml configuration of Travis CI has been fixed to be
+  compatible to the huge changeset of the Freenet core fred which is
+  being developed on fred's next branch.
+  Specifically it was adapted to be compatible with the new Gradle
+  builder of fred which has replaced Ant there - while keeping Ant at
+  WoT so we don't have too much migration efforts going on for now.
+
+  The unit tests of WoT do succeed against the new fred code so
+  hopefully WoT won't delay the release of the fred changes any further
+  than they have already been delayed.
+  This also the first time where the "CI" = continuous integration
+  in Travis CI is really happening to meet its definition:
+  I don't have a Gradle build setup for fred branch next yet so it is of
+  true benefit to be able to test it elsewhere :)
+
+- 0007016: [Bugs] Fix unit test failure on Java 9 (xor)
+
+  Fixes a bug in the unit tests, not in the actual code.
+
+  Symptom was:
+    junit.framework.AssertionFailedError: static final boolean
+    plugins.WebOfTrust.Persistent.$assertionsDisabled expected not same
+
+- 0007017: [Bugs] Fix unit test failure on Java 9 (xor)
+
+  Fixes a bug in the unit tests, not in the actual code.
+
+  Symptom was:
+    testExportIntroduction() would fail due to the Java 9 XML
+    generation code changing the way indentation was produced.
+
+THANKS TO
+
+- ArneBab for being willing to review and deploy WoT.
+- ArneBab for providing pyFreenet which greatly helped in
+  automatically uploading the WoT JAR using Travis CI.

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -1,7 +1,7 @@
 Web of Trust Version 0.4.6 build0021
 ------------------------------------------------------------------------
 
-SUMMARY AND OUTLOOK (detailed changelog is below):
+SUMMARY AND OUTLOOK (detailed changelog is below)
 
 Summary blah blah. Blah blah reference to link [1].
 
@@ -12,7 +12,7 @@ since the previous release, efforts have begun towards achieving 100%
 test coverage in WoT.
 
 
-CHANGELOG - prefixed with the bugtracker issue number:
+CHANGELOG - prefixed with the bugtracker issue number
 
 - 0000001: [category_of_issue_1] title_of_issue_1.......................
            more_lines_of_title (developer_of_issue_1)...................
@@ -85,8 +85,7 @@ CHANGELOG - prefixed with the bugtracker issue number:
     acquired. Without stats, it is impossible to take good guesses which
     random nicknames belong to whom.
 
-
-CHANGELOG about stuff only interesting for developers:
+CHANGELOG about stuff only interesting for developers
 
 - 0006804: [Code quality] Unit tests: Recycle fred simulator code to
            allow tests which do real inserts/fetches (xor)
@@ -288,29 +287,6 @@ CHANGELOG about stuff only interesting for developers:
   As the performance work is currently more important I will refrain
   from renaming all preexisting functions for a while.
 
-- 0006929: [Bugs] Travis CI builds fail due to changes at fred (xor)
+THANKS TO
 
-  The .travis.yml configuration of Travis CI has been fixed to be
-  compatible to the huge changeset of the Freenet core fred which is
-  being developed on fred's next branch.
-  Specifically it was adapted to be compatible with the new Gradle
-  builder of fred which has replaced Ant there - while keeping Ant at
-  WoT so we don't have too much migration efforts going on for now.
-
-  The unit tests of WoT branch next do succeed against the new fred code
-  so hopefully WoT won't delay the release of the fred changes any
-  further than they have already been delayed.
-  This also the first time where the "CI" = continuous integration
-  in Travis CI is really happening to meet its definition:
-  I don't have a Gradle build setup for fred branch next yet so it is of
-  true benefit to be able to test it elsewhere :)
-  Thanks to nextgens for insipiring this by setting up Travis CI at
-  fred!
-
-Thanks to:
   - ArneBab
-  - nextgens
-
-
-Links:
-  [1] https://...

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -1,4 +1,4 @@
-Web of Trust Version 0.4.6 build0020
+Web of Trust Version 0.4.6 build0021
 ------------------------------------------------------------------------
 
 SUMMARY AND OUTLOOK (detailed changelog is below):

--- a/src/plugins/WebOfTrust/IdentityFetcher.java
+++ b/src/plugins/WebOfTrust/IdentityFetcher.java
@@ -536,6 +536,13 @@ public final class IdentityFetcher implements
 			storeStartFetchCommandWithoutCommit(newIdentity);
 	}
 
+	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
+		if(oldIdentity instanceof OwnIdentity)
+			storePreDeleteOwnIdentityCommand((OwnIdentity)oldIdentity);
+		else
+			storeAbortFetchCommandWithoutCommit(oldIdentity);
+	}
+
 	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
 			OwnIdentity newIdentity) {
 		

--- a/src/plugins/WebOfTrust/IdentityFetcher.java
+++ b/src/plugins/WebOfTrust/IdentityFetcher.java
@@ -543,17 +543,26 @@ public final class IdentityFetcher implements
 			storeAbortFetchCommandWithoutCommit(oldIdentity);
 	}
 
-	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
-			OwnIdentity newIdentity) {
+	@Override public void storePreRestoreOwnIdentityCommand(Identity oldIdentity) {
+		// With regards to our duty of deleting object references to the oldIdentity from the
+		// database the commented out code is not necessary as AbortFetchCommand doesn't contain
+		// any, it only stores the ID String.
+		// We can also keep pre-existing downloads running as we want to keep fetching the Identity
+		// anyway because once it became an OwnIdentity it is supposed to be fetched for restoring.
+		// There is also no need to delete a potentially pre-existing AbortFetchCommand here:
+		// storePostRestoreOwnIdentityCommand() will use storeStartFetchCommandWithoutCommit(), and
+		// that function will delete the pre-existing command.
 		
-		// This commented out code is not necessary, we can keep pre-existing downloads running (as
-		// we want to keep fetching the Identity anyway because it's an OwnIdentity):
-		// We don't store an object reference to the oldIdentity anywhere, we only store its ID.
-		// So there's no need to recreate the fetch...
 		/* storeAbortFetchCommandWithoutCommit(oldIdentity); */
-		
-		// ... but we do need to start it if it wasn't being fetched yet.
+	}
+
+	@Override public void storePostRestoreOwnIdentityCommand(OwnIdentity newIdentity) {
+		// Will also delete pre-existing AbortFetchCommands, which is necessary because
+		// storePreRestoreOwnIdentityCommand() doesn't deal with that.
 		storeStartFetchCommandWithoutCommit(newIdentity);
+		
+		// FIXME: Implement the rest of this, e.g. starting the download of the trustees if that
+		// is required by the upcoming interface specification of this function.
 	}
 
 	/** This callback is not used by this class. */

--- a/src/plugins/WebOfTrust/IdentityFetcher.java
+++ b/src/plugins/WebOfTrust/IdentityFetcher.java
@@ -559,10 +559,11 @@ public final class IdentityFetcher implements
 	@Override public void storePostRestoreOwnIdentityCommand(OwnIdentity newIdentity) {
 		// Will also delete pre-existing AbortFetchCommands, which is necessary because
 		// storePreRestoreOwnIdentityCommand() doesn't deal with that.
+		//
+		// If the download is already running the command will cause the download to be restarted.
+		// This fulfills our duty of dealing with a user-supplied edition hint as returned by
+		// newIdentity.getNextEditionToFetch().
 		storeStartFetchCommandWithoutCommit(newIdentity);
-		
-		// FIXME: Implement the rest of this, e.g. starting the download of the trustees if that
-		// is required by the upcoming interface specification of this function.
 	}
 
 	/** This callback is not used by this class. */

--- a/src/plugins/WebOfTrust/Version.java
+++ b/src/plugins/WebOfTrust/Version.java
@@ -20,7 +20,7 @@ public class Version {
 	 * etc, at a minimum any build inserted into auto-update should have a unique 
 	 * version.
 	 */
-	public static final long version = 19;
+	public static final long version = 20;
 	
 	/** Published as an identity property if you own a seed identity. */
 	public static final long mandatoryVersion = 1;

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5513,8 +5513,8 @@ public final class WebOfTrust extends WebOfTrustInterface
 				// - future implementations of IdentityDownloader may propagate an estimate
 				//   of the Dates on the network to allow people to easily notice if someone
 				//   creates a fake identity with the same name as a much older one.
-				// - it ensures the lastFetchedDate which we did already preserve above because
-				//   the non-own Identity may have been fetched already cannot be before the
+				// - it ensures the lastFetchedDate, which we did already preserve above because
+				//   the non-own Identity may have been fetched already, cannot be before the
 				//   creationDate, which would cause the startup database integrity test of the
 				//   OwnIdentity to fail because the creationDate being after lastFetchedDate
 				//   doesn't make any sense.

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5498,10 +5498,9 @@ public final class WebOfTrust extends WebOfTrustInterface
 				
 				identity = new OwnIdentity(this, insertFreenetURI, oldIdentity.getNickname(), oldIdentity.doesPublishTrustList());
 				
-				/* We re-fetch the most recent edition to make sure all trustees are imported */
 				edition = max(edition, oldIdentity.getLastFetchedEdition());
 				identity.restoreEdition(edition, oldIdentity.getLastFetchedDate());
-			
+				
 				identity.setContexts(oldIdentity.getContexts());
 				identity.setProperties(oldIdentity.getProperties());
 				

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5548,8 +5548,6 @@ public final class WebOfTrust extends WebOfTrustInterface
 					newReceivedTrust.storeWithoutCommit();
 				}
 				
-				assert(getReceivedTrusts(oldIdentity).size() == 0);
-	
 				// Copy all received Scores.
 				// We don't have to modify them for the same reason as explained above for Trusts.
 				for(Score oldScore : getScores(oldIdentity)) {
@@ -5567,7 +5565,6 @@ public final class WebOfTrust extends WebOfTrustInterface
 					// Nothing has changed about the actual score so we do not notify.
 					// mSubscriptionManager.storeScoreChangedNotificationWithoutCommit(oldScore, newScore);
 				}
-				assert(getScores(oldIdentity).size() == 0);
 				
 				// Only OwnIdentitys assign Scores to other Identitys so there are no old *given*
 				// Scores to deal with, there only were received ones.
@@ -5594,8 +5591,6 @@ public final class WebOfTrust extends WebOfTrustInterface
 					
 					oldGivenTrust.deleteWithoutCommit();
 				}
-				
-				assert(getGivenTrusts(oldIdentity).size() == 0);
 				
 				// We do not call finishTrustListImport() now: It might trigger execution of computeAllScoresWithoutCommit
 				// which would re-create scores of the old identity. We later call it AFTER deleting the old identity.

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5540,6 +5540,8 @@ public final class WebOfTrust extends WebOfTrustInterface
 					// The following assert() cannot be added because it would always fail:
 					// It would implicitly trigger oldIdentity.equals(identity) which is not the case:
 					// Certain member values such as the edition might not be equal.
+					// TODO: Code quality: Add equalsShallow() and use that. Apply the same concept
+					// for Score in the below loop, and at deleteOwnIdentity().
 					/* assert(newReceivedTrust.equals(oldReceivedTrust)); */
 					
 					oldReceivedTrust.deleteWithoutCommit();

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -3441,8 +3441,12 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 *     try { ... initTrustTreeWithoutCommit(...); Persistent.checkedCommit(mDB, this); }
 	 *     catch(RuntimeException e) { Persistent.checkedRollbackAndThrow(mDB, this, e); }
 	 * }}
+	 * 
+	 * TODO: Code quality: Rename to something else as what it does is creating a Score, not
+	 * a Trust.
 	 *  
 	 * @throws DuplicateScoreException if there already is more than one Score for this identity (should never happen)
+	 *         TODO: Code quality: Throw a plain RuntimeException instead.
 	 */
 	private void initTrustTreeWithoutCommit(OwnIdentity identity) throws DuplicateScoreException {
 		try {

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -2782,6 +2782,14 @@ public final class WebOfTrust extends WebOfTrustInterface
 			if(logDEBUG) Logger.debug(this, "Deleting received scores...");
 			for(Score score : getScores(identity)) {
 				score.deleteWithoutCommit();
+				// FIXME: The Score object won't be able to loads its members from the database
+				// at this point because we just deleted it so we should clone() it before
+				// deleteWithoutCommit() and then pass the clone to SubscriptionManager. This
+				// won't need database upgrade code to repair old databases because the
+				// mSubscriptionManager database is currently deleted at every restart (but that
+				// will change soon due to https://freenet.mantishub.io/view.php?id=6113).
+				// This also applies to all other mSubscriptionManager callbacks in this
+				// function.
 				mSubscriptionManager.storeScoreChangedNotificationWithoutCommit(score, null);
 			}
 

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -2761,6 +2761,8 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 *   However, the implementations of those functions might cause leaks by forgetting to delete certain object members.
 	 *   If you call this function for ALL identities in a database, EVERYTHING should be deleted and the database SHOULD be empty.
 	 *   You then can check whether the database actually IS empty to test for leakage.
+	 * - In the future it may be used as a foundation for code for garbage collection of Identitys.
+	 *   See https://bugs.freenetproject.org/view.php?id=2509
 	 * 
 	 * You have to lock the WebOfTrust, the IntroductionPuzzleStore, the IdentityFetcher, the
 	 * SubscriptionManager and the Persistent.transactionLock() before calling this function.
@@ -2821,9 +2823,10 @@ public final class WebOfTrust extends WebOfTrustInterface
 			if(logDEBUG) Logger.debug(this, "Deleting given trusts...");
 			for(Trust givenTrust : getGivenTrusts(identity)) {
 				givenTrusts.add(givenTrust.clone());
+				// We call computeAllScoresWithoutCommit() by finishTrustListImport() so we do not
+				// have to use removeTrustWithoutCommit() to compute Score changes individually
 				givenTrust.deleteWithoutCommit();
 				mSubscriptionManager.storeTrustChangedNotificationWithoutCommit(givenTrust, null);
-				// We call computeAllScores anyway so we do not use removeTrustWithoutCommit()
 			}
 			
 			mFullScoreComputationNeeded = true; // finishTrustListImport will call computeAllScoresWithoutCommit for us.

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5474,7 +5474,7 @@ public final class WebOfTrust extends WebOfTrustInterface
 		try {
 			OwnIdentity identity;
 			
-			try { // Try replacing an existing non-own version of the identity with an OwnIdentity
+			try { // If it was seen as non-own Identity already replace it with an OwnIdentity
 				Identity oldIdentity = getIdentityByURI(insertFreenetURI);
 				
 				if(oldIdentity instanceof OwnIdentity) {
@@ -5496,7 +5496,6 @@ public final class WebOfTrust extends WebOfTrustInterface
 				
 				mFetcher.storePreRestoreOwnIdentityCommand(oldIdentity);
 				
-				// We already have fetched this identity as a stranger's one. We need to update the database.
 				identity = new OwnIdentity(this, insertFreenetURI, oldIdentity.getNickname(), oldIdentity.doesPublishTrustList());
 				
 				/* We re-fetch the most recent edition to make sure all trustees are imported */

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5455,24 +5455,24 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 */
 	public OwnIdentity restoreOwnIdentityWithoutCommit(FreenetURI insertFreenetURI) throws MalformedURLException, InvalidParameterException {
 		Logger.normal(this, "restoreOwnIdentity(): Starting... ");
-
+		
+		long edition = 0;
+		try {
+			// A negative sign in an USK edition indicates that Freenet should try to fetch
+			// the latest edition before showing something to the user.
+			// This is irrelevant in our case as we will try to fetch the latest edition
+			// anyway, so we can just take the absolute value.
+			// Taking the max(edition, abs(...)) afterwards is necessary because abs()
+			// will return the negative Long.MIN_VALUE if the passed value was MIN_VALUE.
+			// TODO: Code quality: Perhaps instead use Long.MAX_VALUE in that case? This should
+			// also be part of a unit test.
+			edition = max(edition, abs(insertFreenetURI.getEdition()));
+		} catch(IllegalStateException e) {
+			// The user supplied URI did not have an edition specified
+		}
+		
 		try {
 			OwnIdentity identity;
-			long edition = 0;
-			
-			try {
-				// A negative sign in an USK edition indicates that Freenet should try to fetch
-				// the latest edition before showing something to the user.
-				// This is irrelevant in our case as we will try to fetch the latest edition
-				// anyway, so we can just take the absolute value.
-				// Taking the max(edition, abs(...)) afterwards is necessary because abs()
-				// will return the negative Long.MIN_VALUE if the passed value was MIN_VALUE.
-				// TODO: Code quality: Perhaps instead use Long.MAX_VALUE in that case? This should
-				// also be part of a unit test.
-				edition = max(edition, abs(insertFreenetURI.getEdition()));
-			} catch(IllegalStateException e) {
-				// The user supplied URI did not have an edition specified
-			}
 			
 			try { // Try replacing an existing non-own version of the identity with an OwnIdentity
 				Identity oldIdentity = getIdentityByURI(insertFreenetURI);

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5605,6 +5605,13 @@ public final class WebOfTrust extends WebOfTrustInterface
 				// mFullScoreComputationNeeded to true to delay Score computation until finishTrustListImport().
 				// Do benchmarks. However first the problem of storePostRestoreOwnIdentityCommand() having to be
 				// called before finishTrustListImport() as elaborated below must be resolved.
+				// Calling it after that would also ensure that the existing documentation of
+				// storePostRestoreOwnIdentityCommand() is fully correct against future changes:
+				// It claims the Score database has been updated when it is called, but
+				// the purpose of beginTrustListImport() and finishTrustListImport() used to be
+				// to defer Score computation until the latter is called. Currently that isn't the
+				// case anymore (as Score computation was optimized recently as part of build0018)
+				// but it may be changed in the future to defer it again for certain optimizations.
 				for(Trust givenTrust : oldGivenTrusts)
 					setTrustWithoutCommit(identity, givenTrust.getTrustee(), givenTrust.getValue(), givenTrust.getComment());
 				

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5561,9 +5561,6 @@ public final class WebOfTrust extends WebOfTrustInterface
 					
 					oldScore.deleteWithoutCommit();
 					newScore.storeWithoutCommit();
-					
-					// Nothing has changed about the actual score so we do not notify.
-					// mSubscriptionManager.storeScoreChangedNotificationWithoutCommit(oldScore, newScore);
 				}
 				
 				// Only OwnIdentitys assign Scores to other Identitys so there are no old *given*

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -46,6 +46,7 @@ import plugins.WebOfTrust.introduction.IntroductionPuzzleStore;
 import plugins.WebOfTrust.introduction.IntroductionServer;
 import plugins.WebOfTrust.introduction.OwnIntroductionPuzzle;
 import plugins.WebOfTrust.network.input.EditionHint;
+import plugins.WebOfTrust.network.input.IdentityDownloader;
 import plugins.WebOfTrust.network.input.IdentityDownloaderController;
 import plugins.WebOfTrust.network.input.IdentityDownloaderFast;
 import plugins.WebOfTrust.ui.fcp.DebugFCPClient;
@@ -3257,7 +3258,12 @@ public final class WebOfTrust extends WebOfTrustInterface
 	
 	/**
 	 * Gives some {@link Trust} to another Identity.
-	 * It creates or updates an existing Trust object and make the trustee compute its {@link Score}.
+	 * 
+	 * It creates or updates an existing Trust object and computes the received {@link Score}s of
+	 * the trustee.
+	 * It will notify the {@link IdentityDownloader} about resulting changes of whether the trustee
+	 * is eligible for download.
+	 * The {@link SubscriptionManager} will be notified about the changed Trust and changed Scores.
 	 * 
 	 * This function does neither lock the database nor commit the transaction. You have to surround it with
 	 * synchronized(WebOfTrust.this) {

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -5564,10 +5564,10 @@ public final class WebOfTrust extends WebOfTrustInterface
 				}
 				
 				// Only OwnIdentitys assign Scores to other Identitys so there are no old *given*
-				// Scores to deal with, there only were received ones.
+				// Scores to copy, there only were received ones.
 				// Now that the Identity is becoming an OwnIdentity we will have to ensure its given
-				// Scores are computed by using setTrustWithoutCommit() to re-create its Trusts
-				// after we've deleted the old ones.
+				// Scores are computed by using setTrustWithoutCommit() to re-create its given
+				// Trusts after we've deleted the old ones.
 				// We can for now only delete the Trust objects, not re-create them, as the Score
 				// computation code which is invoked by setTrustWithoutCommit() would not work
 				// if two Identitys with the same ID existed at the same time.
@@ -5597,7 +5597,7 @@ public final class WebOfTrust extends WebOfTrustInterface
 				
 				oldIdentity.deleteWithoutCommit();
 				
-				// Update all given trusts. This will also cause given scores to be computed,
+				// Re-create all given Trusts. This will also cause given Scores to be computed,
 				// which is why we had not set them yet.
 				// And it will tell mFetcher to start downloads of trustees which became eligible
 				// for download due to now having received a chain of Trust from an OwnIdentity.

--- a/src/plugins/WebOfTrust/WebOfTrustInterface.java
+++ b/src/plugins/WebOfTrust/WebOfTrustInterface.java
@@ -41,11 +41,11 @@ public abstract class WebOfTrustInterface {
 	 * the Freenet development team provides a list of seed identities - each of them is one of the developers.
 	 */
 	static final String[] SEED_IDENTITIES = new String[] { 
-		"USK@QeTBVWTwBldfI-lrF~xf0nqFVDdQoSUghT~PvhyJ1NE,OjEywGD063La2H-IihD7iYtZm3rC0BP6UTvvwyF5Zh4,AQACAAE/WebOfTrust/1524", // xor
+		"USK@QeTBVWTwBldfI-lrF~xf0nqFVDdQoSUghT~PvhyJ1NE,OjEywGD063La2H-IihD7iYtZm3rC0BP6UTvvwyF5Zh4,AQACAAE/WebOfTrust/1531", // xor
 		"USK@z9dv7wqsxIBCiFLW7VijMGXD9Gl-EXAqBAwzQ4aq26s,4Uvc~Fjw3i9toGeQuBkDARUV5mF7OTKoAhqOA9LpNdo,AQACAAE/WebOfTrust/5156", // Toad
-		"USK@o2~q8EMoBkCNEgzLUL97hLPdddco9ix1oAnEa~VzZtg,X~vTpL2LSyKvwQoYBx~eleI2RF6QzYJpzuenfcKDKBM,AQACAAE/WebOfTrust/17330", // Bombe
+		"USK@o2~q8EMoBkCNEgzLUL97hLPdddco9ix1oAnEa~VzZtg,X~vTpL2LSyKvwQoYBx~eleI2RF6QzYJpzuenfcKDKBM,AQACAAE/WebOfTrust/19619", // Bombe
 		"USK@D3MrAR-AVMqKJRjXnpKW2guW9z1mw5GZ9BB15mYVkVc,xgddjFHx2S~5U6PeFkwqO5V~1gZngFLoM-xaoMKSBI8,AQACAAE/WebOfTrust/8231", // zidel
-		"USK@nmTkFmn0Akz1-G9iIN2w6lsQEAfWkpQw3ckOxtwMh2Q,Du9GQxGDj0Nax4zN9-ANTPetx-GxOoWaRf6Gq6Nbh1o,AQACAAE/WebOfTrust/9141", // operhiem1
+		"USK@nmTkFmn0Akz1-G9iIN2w6lsQEAfWkpQw3ckOxtwMh2Q,Du9GQxGDj0Nax4zN9-ANTPetx-GxOoWaRf6Gq6Nbh1o,AQACAAE/WebOfTrust/11558", // operhiem1
 	};
 	
 	abstract public List<Identity> getAllIdentities();

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -84,8 +84,16 @@ public interface IdentityDownloader extends Daemon {
 	 * deleting an {@link OwnIdentity}.
 	 * 
 	 * After the callback returns the oldIdentity will be deleted from the database.
-	 * Any {@link Score}s it has given to other {@link Identity}s as specified by
+	 * It will be replaced by a non-own {@link Identity} object. Its given and received
+	 * {@link Trust}s, and its received {@link Score}s will keep existing by being replaced with
+	 * objects which to point to the replacement Identity.
+	 * Any Scores the oldIdentity has given to other Identitys as specified by
 	 * {@link WebOfTrust#getGivenScores(OwnIdentity)} will be deleted then.
+	 * 
+	 * After this callback has returned, and once the replacement Identity has been created and the
+	 * {@link Trust} and Score database fully adapted to it, WoT will call
+	 * {@link #storePostDeleteOwnIdentityCommand(Identity)} in order to allow implementations to
+	 * start download of the replacement Identity if it is eligible for download.
 	 * 
 	 * Thus implementations have to:
 	 * - remove any object references to the oldIdentity object from the db4o database as they
@@ -105,13 +113,7 @@ public interface IdentityDownloader extends Daemon {
 	 * Implementations can assume that when this function is called:
 	 * - the OwnIdentity still is stored in the database, the replacement Identity object has not
 	 *   been created yet.
-	 * - the Score database has not been changed yet.
-	 * I.e. they can assume that nothing has changed about the OwnIdentity or any other aspect
-	 * related to it yet.
-	 * 
-	 * After this callback has returned, and once the replacement Identity has been created and the
-	 * {@link Trust} and Score database fully adapted to it, WoT will call
-	 * {@link #storePostDeleteOwnIdentityCommand(Identity)}. */
+	 * - the Trust and Score database has not been changed yet. */
 	@NeedsTransaction void storePreDeleteOwnIdentityCommand(OwnIdentity oldIdentity);
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -363,10 +363,8 @@ public interface IdentityDownloader extends Daemon {
 	 * ATTENTION: For debugging purposes only.
 	 * 
 	 * Returns the effective state of whether the downloader will download an {@link Identity}
-	 * = returns what was last instructed to this downloader using
-	 * {@link #storeStartFetchCommandWithoutCommit(Identity)}
-	 * or {@link #storeAbortFetchCommandWithoutCommit(Identity)}:
-	 * True if the last command was one for starting the fetch, false if it was for stopping it.
+	 * = returns what was last instructed to this downloader using all the callbacks in this
+	 * interface.
 	 * 
 	 * This considers both queued commands as well as already processed commands.
 	 * It will also check for contradictory commands in the command queue which would be a bug

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -57,30 +57,6 @@ import freenet.keys.FreenetURI;
  * this interface. */
 public interface IdentityDownloader extends Daemon {
 
-	/* FIXME: The following five function declarations should replace the complex cruft of using all
-	 * the other following functions at:
-	 * - WebOfTrust.deleteWithoutCommit(Identity)
-	 * - WebOfTrust.deleteOwnIdentity()
-	 * - WebOfTrust.restoreDownIdentity()
-	 * 
-	 * Namely they will resolve the issue of having deletion/restoring only being handled by
-	 * single callbacks instead of having pre/post callbacks, which used to cause the problems of:
-	 * - The Trust and especially Score database not yet being fully updated to reflect the Identity
-	 *   type changes at the point when the old callbacks were being called, but the callbacks
-	 *   needing that (fully updating them before wasn't possible due to constraints of the
-	 *   implementations of the said functions at WebOfTrust. E.g. Score computation doesn't work if
-	 *   two copies of the same Identity exist in the database).
-	 * - both the old and the new Identity existing at the same time when the callbacks were being
-	 *   called, which would break database queries for the Identity by ID.
-	 * 
-	 * Their implementations should fully replace:
-	 * - storeDeleteOwnIdentityCommandWithoutCommit()
-	 * - storeRestoreOwnIdentityCommandWithoutCommit().
-	 * 
-	 * The other functions will keep existing for their remaining other purposes and should have
-	 * their JavaDoc adapted to state that identity deletion/restoring is handled by these new
-	 * functions here. */
-	
 	/**
 	 * Called by {@link WebOfTrust#deleteOwnIdentity(String)} before any action is taken towards
 	 * deleting an {@link OwnIdentity}.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -15,6 +15,7 @@ import plugins.WebOfTrust.Score;
 import plugins.WebOfTrust.SubscriptionManager;
 import plugins.WebOfTrust.Trust;
 import plugins.WebOfTrust.WebOfTrust;
+import plugins.WebOfTrust.network.input.IdentityDownloaderFast.DownloadSchedulerCommand;
 import plugins.WebOfTrust.util.Daemon;
 import freenet.keys.FreenetURI;
 
@@ -24,7 +25,8 @@ import freenet.keys.FreenetURI;
  * the {@link IdentityFileProcessor}.
  * 
  * Implementations are allowed to and do store pointers to {@link Identity} and {@link OwnIdentity}
- * objects in their database, currently as part of {@link EditionHint} objects.
+ * objects in their database, e.g. as part of {@link EditionHint} objects and
+ * {@link DownloadSchedulerCommand}s.
  * They must not store references to any other objects which are not a type managed by their own
  * database, e.g. {@link Trust} or {@link Score} (because this interface only has callbacks for
  * changes to Identity objects).

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -274,42 +274,6 @@ public interface IdentityDownloader extends Daemon {
 	void storeAbortFetchCommandWithoutCommit(Identity identity);
 
 	/**
-	 * Called by {@link WebOfTrust#restoreOwnIdentityWithoutCommit(FreenetURI)} when the class of an
-	 * {@link Identity} changes to {@link OwnIdentity}.
-	 * Is supposed to adjust the IdentityDownloader's decision of which {@link Identity}s to
-	 * download, e.g. due to the facts that:
-	 * - Identitys which have received a >= 0 Trust by an OwnIdentity are always supposed to be
-	 *   downloaded.
-	 * - OwnIdentitys are also always downloaded.
-	 * Please notice that the user may provide a {@link FreenetURI#getSuggestedEdition()} in the
-	 * USK URI when restoring the OwnIdentity, and thus if a download is already running the
-	 * edition may need to be adjusted to the {@link Identity#getNextEditionToFetch()} of the given
-	 * newIdentity.
-	 * 
-	 * Must ensure that no references to the oldIdentity object are stored in the db4o database by
-	 * the particular IdentityDownloader implementation as the object will be deleted from the
-	 * database after the callback returns.
-	 * 
-	 * Synchronization:
-	 * This function is guaranteed to be called while the following locks are being held in the
-	 * given order:
-	 * synchronized(Instance of WebOfTrust)
-	 * synchronized(WebOfTrust.getIdentityDownloaderController())
-	 * synchronized(Persistent.transactionLock(WebOfTrust.getDatabase())) 
-	 * 
-	 * FIXME: Implement at the child classes IdentityDownloaderFast and IdentityDownloaderSlow.
-	 * Adapt restoreOwnIdentity() to call it. Then JavaDoc this once the requirements of the
-	 * callback have been become apparent by implementing it. 
-	 * This callback was introduced during attempts to implement calling of
-	 * {@link #storeTrustChangedCommandWithoutCommit(Trust, Trust)} by restoreOwnIdentty(), during
-	 * which it was discovered that it would be too complex to deploy that callback under the
-	 * circumstances of restoreOwnIdentity(). Those circumstances are described at the JavaDoc of
-	 * that callback.
-	 * Therefore please also take the requirements of that callback into consideration for the
-	 * pending documentation of this callback here. */
-	void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity, OwnIdentity newIdentity);
-
-	/**
 	 * Called under almost the same circumstances as
 	 * {@link SubscriptionManager#storeTrustChangedNotificationWithoutCommit()} except for the
 	 * following differences:

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -23,15 +23,20 @@ import freenet.keys.FreenetURI;
  * They are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which is consumed by
  * the {@link IdentityFileProcessor}.
  * 
+ * Implementations are allowed to and do store pointers to {@link Identity} and {@link OwnIdentity}
+ * objects in their database, currently as part of {@link EditionHint} objects.
+ * They must not store references to any other objects which are not a type managed by their own
+ * database, e.g. {@link Trust} or {@link Score} (because this interface only has callbacks for
+ * changes to Identity objects).
  * FIXME: 
- * Implementations are allowed to and do store pointers to Identity objects in their database,
- * currently as part of {@link EditionHint} objects.
  * Thus we must introduce a new callback which gets called before deletion of an Identity to ensure
  * the IdentityDownloader implementations delete the objects pointing to the to-be-deleted Identity.
  * Further at least the following functions must be amended to call the new callback:
  * - {@link WebOfTrust#deleteWithoutCommit(Identity)}
  * - {@link WebOfTrust#deleteOwnIdentity(String)}
  * - {@link WebOfTrust#restoreOwnIdentityWithoutCommit(freenet.keys.FreenetURI)}
+ * EDIT: This is being resolved by the five new callbacks at the beginning of the interface, it can
+ * be removed once they're done (as specified by the FIXMEs there).
  * 
  * <b>Locking:</b>
  * Implementations  must synchronize transactions by taking the following locks in the given order:

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -274,41 +274,6 @@ public interface IdentityDownloader extends Daemon {
 	void storeAbortFetchCommandWithoutCommit(Identity identity);
 
 	/**
-	 * Called by {@link WebOfTrust#deleteOwnIdentity(String)} when the class of an
-	 * {@link OwnIdentity} changes to {@link Identity}.
-	 * 
-	 * The oldIdentity object will be deleted from the database immediately after this function
-	 * returns. Implementations must thus ensure that they remove any references to the Identity
-	 * object in their db4o databases.
-	 * The {@link Trust} and {@link Score} database is guaranteed to be up to date when this
-	 * function is called and thus can be used by it.
-	 * 
-	 * Synchronization:
-	 * This function is guaranteed to be called while the following locks are being held in the
-	 * given order:
-	 * synchronized(Instance of WebOfTrust)
-	 * synchronized(WebOfTrust.getIdentityDownloaderController())
-	 * synchronized(Persistent.transactionLock(WebOfTrust.getDatabase()))
-	 * 
-	 * FIXME: Implement at the child classes. Adapt deleteOwnIdentity() to call it instead  of
-	 * {@link #storeTrustChangedCommandWithoutCommit(Trust, Trust)}. Then provide more JavaDoc here
-	 * once the requirements of the callback have become apparent by implementing it.
-	 * Also see {@link #storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)} which
-	 * can be considered as a draft for this callback.
-	 * This callback was introduced during attempts to implement calling of
-	 * storeTrustChangedCommandWithoutCommit() by restoreOwnIdentty(), during which it was
-	 * discovered that it would be too complex to deploy that callback under the
-	 * circumstances of restoreOwnIdentity() - said circumstances are probably similar for
-	 * deleteOwnIdentity() which is subject of this callback here.
-	 * Those circumstances are described at the JavaDoc of that callback.
-	 * Therefore please also take the requirements of that callback into consideration for the
-	 * pending documentation of this callback here.
-	 * 
-	 * FIXME: The names of these callbacks are really getting excessively long, shorten all of them
-	 * in a coherent fashion at once. */
-	void storeDeleteOwnIdentityCommandWithoutCommit(OwnIdentity oldIdentity, Identity newIdentity);
-
-	/**
 	 * Called by {@link WebOfTrust#restoreOwnIdentityWithoutCommit(FreenetURI)} when the class of an
 	 * {@link Identity} changes to {@link OwnIdentity}.
 	 * Is supposed to adjust the IdentityDownloader's decision of which {@link Identity}s to

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -262,19 +262,8 @@ public interface IdentityDownloader extends Daemon {
 	 *   has rated it as trustworthy enough for us to download it.
 	 *   The {@link Trust} and {@link Score} database is guaranteed to be up to date when this
 	 *   function is called and thus can be used by it.
-	 * - in special cases such as deletion/restoring of an OwnIdentity.
-	 *   FIXME: For those special cases we probably shouldn't call it but instead only call:
-	 *   - For restoring {@link #storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)}
-	 *   - For deletion the preoposed similar callback, the proposal is at
-	 *     {@link #storeTrustChangedCommandWithoutCommit(Trust, Trust)}.
-	 *   (This also applies to {@link #storeStartFetchCommandWithoutCommit(Identity)}, see the FIXME
-	 *   at {@link WebOfTrust#restoreOwnIdentityWithoutCommit(FreenetURI)}.)
-	 *   That is probably necessary because in those special cases the Identity object will be
-	 *   deleted by WoT after the callback returns. This implies that the callback must not store
-	 *   a pointer to the Identity object to the database, which would be more obvious under the
-	 *   circumstances of special callbacks for restoring/deletion: They will be passed two
-	 *   Identity objects so it is obvious that one is going away. Further deploying two callbacks
-	 *   for the same event is more confusing than having only one.
+	 * - but is not called upon deletion/restoring of an OwnIdentity, see the other callbacks for
+	 *   that.
 	 * 
 	 * Synchronization:
 	 * This function is guaranteed to be called while the following locks are being held in the

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -241,7 +241,8 @@ public interface IdentityDownloader extends Daemon {
 	 *   rated it as trustworthy enough for us to download it.
 	 *   The {@link Trust} and {@link Score} database is guaranteed to be up to date when this
 	 *   function is called and thus can be used by it.
-	 * - in special cases such as creation/deletion/restoring of an OwnIdentity.
+	 * - when an OwnIdentity is created (but not when it is deleted/restored, see the other
+	 *   callbacks for that).
 	 * - May also be called to notify the IdentityDownloader about a changed
 	 *   {@link Identity#getNextEditionToFetch()} (e.g. due to  {@link Identity#markForRefetch()})
 	 *   even if the Identity was already eligible for fetching before.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -65,7 +65,7 @@ public interface IdentityDownloader extends Daemon {
 	 * start download of the replacement Identity if it is eligible for download.
 	 * 
 	 * Thus implementations have to:
-	 * - remove any object references to the oldIdentity object from the db4o database as they
+	 * - remove any object references to the oldIdentity object from their db4o database as they
 	 *   would otherwise be nulled by the upcoming deletion of it.
 	 * - stop downloading of any Identitys who aren't eligible for download anymore because
 	 *   they were eligible solely due to one of the to-be-deleted Scores (see the JavaDoc of
@@ -119,7 +119,7 @@ public interface IdentityDownloader extends Daemon {
 	 *   of the replacement Identity if necessary, but there will be none.
 	 * 
 	 * Thus implementations have to:
-	 * - remove any object references to the oldIdentity object from the db4o database as they
+	 * - remove any object references to the oldIdentity object from their db4o database as they
 	 *   would otherwise be nulled by the upcoming deletion of it.
 	 * - stop downloading of any Identitys who aren't eligible for download anymore because
 	 *   they were eligible solely due to one of the to-be-deleted Scores (see the JavaDoc of
@@ -158,7 +158,7 @@ public interface IdentityDownloader extends Daemon {
 	 * the recipients of its newly created positive {@link WebOfTrust#getGivenScores(OwnIdentity)}.
 	 * 
 	 * Thus implementations have to:
-	 * - remove any object references to the oldIdentity object from the db4o database as they
+	 * - remove any object references to the oldIdentity object from their db4o database as they
 	 *   would otherwise be nulled by the upcoming deletion of it.
 	 * - stop downloading the oldIdentity.
 	 * 

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -215,11 +215,15 @@ public interface IdentityDownloader extends Daemon {
 	 *   The user may have provided a {@link FreenetURI#getSuggestedEdition()} in the
 	 *   USK URI when restoring the OwnIdentity.
 	 * 
-	 * NOTICE: Implementations do NOT have to start the download of the {@link Score} recipients of
-	 * the OwnIdentity.
-	 * This is because for technical reasons the downloads to be started from the given Scores of
-	 * the newIdentity will have already been started by other callbacks having been triggered by
-	 * restoreOwnidentity(). */
+	 * NOTICE: Implementations do NOT have to start the download of the {@link Trust} and
+	 * {@link Score} recipients of the OwnIdentity.
+	 * This is because for technical reasons the downloads to be started from the given Trusts and
+	 * Scores of the newIdentity will have already been started by other callbacks having been
+	 * triggered by restoreOwnidentity().
+	 * These callbacks might e.g. be:
+	 * - {@link #storeStartFetchCommandWithoutCommit(Identity)}
+	 * - {@link #storeTrustChangedCommandWithoutCommit(Trust, Trust)}
+	 * Implementations of this callback here must be safe against side effects from that. */
 	@NeedsTransaction void storePostRestoreOwnIdentityCommand(OwnIdentity newIdentity);
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -332,10 +332,6 @@ public interface IdentityDownloader extends Daemon {
 	 * Returns the effective state of whether the downloader will download an {@link Identity}
 	 * = returns what was last instructed to this downloader using all the callbacks in this
 	 * interface.
-	 * 
-	 * This considers both queued commands as well as already processed commands.
-	 * It will also check for contradictory commands in the command queue which would be a bug
-	 * (= both start and stop command at once).
 	 *
 	 * Synchronization:
 	 * This function is guaranteed to be called while the following locks are being held in the

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -139,6 +139,13 @@ public interface IdentityDownloader extends Daemon {
 	 * - {@link WebOfTrust#getGivenScores(OwnIdentity)} if the Identity was an {@link OwnIdentity}.
 	 * - {@link WebOfTrust#getScores(Identity)}
 	 * 
+	 * After this callback has returned, in opposite to the other callbacks of this interface, no
+	 * such callback as "storePostDeleteIdentityCommand()" will be called. This is because:
+	 * - there will be no replacement Identity to pass by a callback.
+	 * - deletion of an Identity can only cause abortion of downloads, not starting - which would
+	 *   typically be the job of a Post-deletion version of this callback with starting the download
+	 *   of the replacement Identity if necessary, but there will be none.
+	 * 
 	 * Thus implementations have to:
 	 * - remove any object references to the oldIdentity object from the db4o database as they
 	 *   would otherwise be nulled by the upcoming deletion of it.
@@ -155,16 +162,7 @@ public interface IdentityDownloader extends Daemon {
 	 * 
 	 * Implementations can assume that when this function is called:
 	 * - the Identity still is stored in the database.
-	 * - the Trust and Score database has not been changed yet.
-	 * I.e. they can assume that nothing has changed about the Identity or any other aspect related
-	 * to it yet.
-	 * 
-	 * After this callback has returned, in opposite to the other callbacks of this interface, no
-	 * such callback as "storePostDeleteIdentityCommand()" will be called. This is because:
-	 * - there will be no replacement object for the deleted Identity
-	 * - deletion of an Identity can only cause aborting of downloads, not starting - which would
-	 *   typically be the job of a Post-deletion version of this callback with starting the download
-	 *   of the replacement Identity if necessary. */
+	 * - the Trust and Score database has not been changed yet. */
 	@NeedsTransaction void storePreDeleteIdentityCommand(Identity oldIdentity);
 
 	// There is no replacement Identity when a non-own Identity is deleted.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -298,9 +298,6 @@ public interface IdentityDownloader extends Daemon {
 	 *       deleting the trust objects and re-creating them in separate calls to
 	 *       {@link WebOfTrust#removeTrust(String, String)} and
 	 *       {@link WebOfTrust#setTrust(String, String, byte, String)}.
-	 *       If you drop this constraint then also adapt the implementation of this callback
-	 *       {@link IdentityDownloaderController#storeTrustChangedCommandWithoutCommit(Trust,
-	 *       Trust)} to not check for it anymore in an assert().
 	 *       EDIT: It certainly is not called in the case of restoreOwnIdentity(), see
 	 *       {@link #storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)}.
 	 *   * a Trust is created or deleted.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -30,15 +30,6 @@ import freenet.keys.FreenetURI;
  * They must not store references to any other objects which are not a type managed by their own
  * database, e.g. {@link Trust} or {@link Score} (because this interface only has callbacks for
  * changes to Identity objects).
- * FIXME: 
- * Thus we must introduce a new callback which gets called before deletion of an Identity to ensure
- * the IdentityDownloader implementations delete the objects pointing to the to-be-deleted Identity.
- * Further at least the following functions must be amended to call the new callback:
- * - {@link WebOfTrust#deleteWithoutCommit(Identity)}
- * - {@link WebOfTrust#deleteOwnIdentity(String)}
- * - {@link WebOfTrust#restoreOwnIdentityWithoutCommit(freenet.keys.FreenetURI)}
- * EDIT: This is being resolved by the five new callbacks at the beginning of the interface, it can
- * be removed once they're done (as specified by the FIXMEs there).
  * 
  * <b>Locking:</b>
  * Implementations  must synchronize transactions by taking the following locks in the given order:

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -204,6 +204,12 @@ public interface IdentityDownloader extends Daemon {
 	 * was restored, either by replacing a non-own {@link Identity} with it or by creating it from
 	 * scratch.
 	 * 
+	 * This implies that:
+	 * - the non-own Identity has been deleted from the the database, the given replacement
+	 *   OwnIdentity object has been stored.
+	 * - the {@link Trust} and {@link Score} database has been fully updated to reflect the
+	 *   necessary changes.
+	 * 
 	 * For understanding the surrounding conditions of restoreOwnIdentity() please read the
 	 * documentation of {@link #storePreRestoreOwnIdentityCommand(Identity)} which is called before
 	 * this callback here.

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -200,9 +200,26 @@ public interface IdentityDownloader extends Daemon {
 	@NeedsTransaction void storePreRestoreOwnIdentityCommand(Identity oldIdentity);
 
 	/**
-	 * FIXME: Document similar to the above callbacks.
-	 * Document that for technical reasons the downloads to be started from the given Scores can
-	 * have already been started (due to restoreOwnIdentity using setTrustWithoutCommit()). */
+	 * Called by {@link WebOfTrust#restoreOwnIdentity(FreenetURI)} after an {@link OwnIdentity}
+	 * was restored, either by replacing a non-own {@link Identity} with it or by creating it from
+	 * scratch.
+	 * 
+	 * For understanding the surrounding conditions of restoreOwnIdentity() please read the
+	 * documentation of {@link #storePreRestoreOwnIdentityCommand(Identity)} which is called before
+	 * this callback here.
+	 * 
+	 * Implementations have to:
+	 * - start the download of the given newIdentity.
+	 * - If a download is already running adjust the edition to the
+	 *   {@link Identity#getNextEditionToFetch()} of the newIdentity:
+	 *   The user may have provided a {@link FreenetURI#getSuggestedEdition()} in the
+	 *   USK URI when restoring the OwnIdentity.
+	 * 
+	 * NOTICE: Implementations do NOT have to start the download of the {@link Score} recipients of
+	 * the OwnIdentity.
+	 * This is because for technical reasons the downloads to be started from the given Scores of
+	 * the newIdentity will have already been started by other callbacks having been triggered by
+	 * restoreOwnidentity(). */
 	@NeedsTransaction void storePostRestoreOwnIdentityCommand(OwnIdentity newIdentity);
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
@@ -203,6 +203,7 @@ public final class IdentityDownloaderController implements IdentityDownloader, D
 
 	@Override public void storePostDeleteOwnIdentityCommand(Identity newIdentity) {
 		assert(newIdentity != null);
+		assert(!(newIdentity instanceof OwnIdentity));
 		
 		for(IdentityDownloader d : mDownloaders)
 			d.storePostDeleteOwnIdentityCommand(newIdentity);
@@ -210,6 +211,8 @@ public final class IdentityDownloaderController implements IdentityDownloader, D
 
 	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
 		assert(oldIdentity != null);
+		// It *CAN* be an OwnIdentity!
+		/* assert(!(newIdentity instanceof OwnIdentity)); */
 		
 		for(IdentityDownloader d : mDownloaders)
 			d.storePreDeleteIdentityCommand(oldIdentity);
@@ -217,7 +220,8 @@ public final class IdentityDownloaderController implements IdentityDownloader, D
 
 	@Override public void storePreRestoreOwnIdentityCommand(Identity oldIdentity) {
 		assert(oldIdentity != null);
-	
+		assert(!(oldIdentity instanceof OwnIdentity));
+		
 		for(IdentityDownloader d : mDownloaders)
 			d.storePreRestoreOwnIdentityCommand(oldIdentity);
 	}

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
@@ -120,24 +120,6 @@ public final class IdentityDownloaderController implements IdentityDownloader, D
 			d.storeAbortFetchCommandWithoutCommit(identity);
 	}
 
-	@Override public void storeDeleteOwnIdentityCommandWithoutCommit(OwnIdentity oldIdentity,
-			Identity newIdentity) {
-		
-		assert(oldIdentity.getID() == newIdentity.getID());
-		
-		for(IdentityDownloader d : mDownloaders)
-			d.storeDeleteOwnIdentityCommandWithoutCommit(oldIdentity, newIdentity);
-	}
-
-	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
-			OwnIdentity newIdentity) {
-		
-		assert(oldIdentity.getID() == newIdentity.getID());
-		
-		for(IdentityDownloader d : mDownloaders)
-			d.storeRestoreOwnIdentityCommandWithoutCommit(oldIdentity, newIdentity);
-	}
-
 	@Override public void storeTrustChangedCommandWithoutCommit(Trust oldTrust, Trust newTrust) {
 		// Check sanity of passed Trusts.
 		assert(oldTrust != null || newTrust != null);

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderController.java
@@ -153,9 +153,7 @@ public final class IdentityDownloaderController implements IdentityDownloader, D
 		// function for whether they are safe in all those cases.
 		assert(
 			(newTrust == null ^ oldTrust == null) ||
-			(newTrust.getValue() != oldTrust.getValue()) ||
-			(	  (newTrust.getTruster() instanceof OwnIdentity)
-				^ (oldTrust.getTruster() instanceof OwnIdentity))
+			(newTrust.getValue() != oldTrust.getValue())
 		) : "storeTrustChangedCommandWithoutCommit() called for irrelevant Trust change!";
 		
 		

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -1140,6 +1140,8 @@ public final class IdentityDownloaderFast implements
 	}
 
 	@Override public boolean getShouldFetchState(Identity identity) {
+		// Will implicitly check for contradicting commands, i.e. both StartDownloadCommand
+		// and StopDownloadCommand existing at once, or duplicate commands, and throw upon that.
 		DownloadSchedulerCommand c = getQueuedCommand(identity);
 		
 		// If a command is stored then the interface specification demands that our return value is

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -604,39 +604,19 @@ public final class IdentityDownloaderFast implements
 		}
 	}
 
-	// FIXME: This function was created from splitting up the previous
-	// storeRestoreOwnIdentityCommandWithoutCommit() into Pre/Post functions as demanded by the
-	// new IdentityDownloader interface specfication. The Pre one was reviewed, the post one was not
-	// yet reviewed. -> Review this once the interace for the Post function has been specified.
 	@Override public void storePostRestoreOwnIdentityCommand(OwnIdentity newIdentity) {
-		
 		// Keep a potentially running download as is so we don't lose fred's progress on polling the
 		// USK.
 		// Notice: When entering the USK for restoring the user may have supplied a higher edition
 		// than what we had passed to the running USK subscription so it is necessary to somehow
 		// make the USK code aware of that. There is no need to do so in this class:
-		// The IdentityDownloaderSlow will store an EditionHint for the edition of the newIdentity
-		// in its implementation of this callback to conduct a download attempt on the higher
-		// edition.
+		// The IdentityDownloaderSlow by contract of the interface will have to store an EditionHint
+		// for the edition of the newIdentity in its implementation of this callback.
+		// FIXME: Ensure it really does that.
 		if(!mDownloads.containsKey(newIdentity.getID())) {
 			new StartDownloadCommand(mWoT, newIdentity).storeWithoutCommit();
 			mDownloadSchedulerThread.triggerExecution();
 		}
-		
-		// FIXME: Decide whether we do this here or keep requiring callers to deal with it like it
-		// is currently implemented at WebOfTrust.restoreOwnIdentityWithoutCommit() (implicitly by
-		// its calls to storeTrustWithoutCommit()).
-		// Either way document the decision at the IdentityDownloader's specification of this
-		// callback.
-		/*
-		for(Trust t : mWoT.getGivenTrusts(newIdentity)) {
-			if(t.getValue() >= 0) {
-				// Start fetching it, perhaps using one of these:
-				// storeStartFetchCommandWithoutCommit(t.getTrustee());
-				// storeStartFetchCommandWithoutCommit_Checked(t.getTrustee());
-			}
-		}
-		 */
 	}
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -551,7 +551,6 @@ public final class IdentityDownloaderFast implements
 		// for the purpose of WebOfTrust.restoreOwnIdentity(). Thus we new to abort a potentially
 		// pre-existing download.
 		storeAbortFetchCommandWithoutCommit_Checked(oldIdentity);
-
 	}
 
 	@Override public void storePostDeleteOwnIdentityCommand(Identity newIdentity) {

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -560,6 +560,15 @@ public final class IdentityDownloaderFast implements
 			storeStartFetchCommandWithoutCommit_Checked(newIdentity);
 	}
 
+	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
+		if(oldIdentity instanceof OwnIdentity)
+			storePreDeleteOwnIdentityCommand((OwnIdentity)oldIdentity);
+		else {
+			if(shouldDownload(oldIdentity))
+				storeAbortFetchCommandWithoutCommit_Checked(oldIdentity);
+		}
+	}
+
 	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
 			OwnIdentity newIdentity) {
 		

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderFast.java
@@ -593,6 +593,10 @@ public final class IdentityDownloaderFast implements
 				// which would become null by the upcoming deletion of the Identity.
 				// Thus we must delete the stale command to create a fresh one later on.
 				pendingCommand.deleteWithoutCommit();
+				
+				// Not valid here: StartDownloadCommands may be stored when there already is a
+				// download - for handling of Identity.markForRefetch().
+				/* assert(!mDownloads.containsKey(id)); */
 			} else {
 				assert(pendingCommand instanceof StopDownloadCommand);
 				

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -1091,13 +1091,17 @@ public final class IdentityDownloaderSlow implements
 	}
 
 	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
-		// Both stops the download of the Identity by deleting all EditionHint objects it has
-		// received as well as deleting all EditionHint objects it has given to other Identitys.
-		// Thus complies with our job of deleting all objects in the db4o database which point to
-		// the oldIdentity and those induced by Trusts/Scores it has given/received (in our case
-		// only by the Trusts as we don't store anything due to Scores, but Scores are a consequence
-		// of Trusts and thus are also dealt with implicitly).
-		storeAbortFetchCommandWithoutCommit(oldIdentity);
+		if(oldIdentity instanceof OwnIdentity) {
+			storePreDeleteOwnIdentityCommand((OwnIdentity)oldIdentity);
+		} else {
+			// Both stops the download of the Identity by deleting all EditionHint objects it has
+			// received as well as deleting all EditionHint objects it has given to other Identitys.
+			// Thus complies with our job of deleting all objects in the db4o database which point
+			// to the oldIdentity and those induced by Trusts/Scores it has given/received (in our
+			// case only by the Trusts as we don't store anything due to Scores, but Scores are a
+			// consequence of Trusts and thus are also dealt with implicitly).
+			storeAbortFetchCommandWithoutCommit(oldIdentity);
+		}
 	}
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -1134,41 +1134,6 @@ public final class IdentityDownloaderSlow implements
 		storeStartFetchCommandWithoutCommit(newIdentity);
 	}
 
-	/**
-	 * FIXME: Implement, see
-	 * {@link IdentityDownloader#storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)}
-	 * When implementing it make sure to store an EditionHint for the edition of the newIdentity:
-	 * IdentityDownloaderFast won't restart a pending USK subscription to the Identity so it won't
-	 * become aware of the user having provided a higher edition number when entering the USK of
-	 * the OwnIdentity.
-	 */
-	@Override public void storeRestoreOwnIdentityCommandWithoutCommit(Identity oldIdentity,
-			OwnIdentity newIdentity) {
-		
-		// These are what WebOfTrust.restoreOwnIdentity() used to call before this callback here
-		// was added. When resolving the above FIXME of actually implementing this function you
-		// should review whether what they do is sufficient to deal with the requirements.
-		// Also notice that the point in time where storeStartFetchCommandWithoutCommit() is called
-		// was changed by moving it to this place: Previously it was being called by
-		// WebOfTrust.restoreOwnIdenityWithoutCommit() after the Trust/Score database was fully
-		// updated to comply with the restoring procedure. Now by inlineing the call to it into
-		// this function here it is called after having replaced the Trusts/Scores pointing to
-		// the oldIdentity, but before restoring its given Trusts using
-		// WebOfTrust.storeTrustWithoutCommit(). This intermediate state of the Trust/Score database
-		// may have bad side effects on the database queries of storeStartFetchCommand...().
-		// To alleviate that it may be indicated to split up this callback into two:
-		// storePreRestoreOwnIdentityCommand...() and storePostRestoreOwnIdentityCommand...().
-		// The former would be called before deletion of the oldIdentity, the latter after the
-		// Trust/Score database has been fully updated.
-		// Perhaps we can also go for handling part of restoring as a special case of Identity
-		// deletion by introducing a storeDeleteIdentityCommmand() instead of storePre...().
-		// That function could also fulfill the purpose of storeDeleteOwnIdentityCommand...().
-		/*
-		storeAbortFetchCommandWithoutCommit(oldIdentity);
-		storeStartFetchCommandWithoutCommit(newIdentity);
-		*/
-	}
-
 	/** This callback is not used by this class. */
 	@Override public void storeTrustChangedCommandWithoutCommit(Trust oldTrust, Trust newTrust) {
 	}

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -983,8 +983,8 @@ public final class IdentityDownloaderSlow implements
 	 * Using this function for that purpose is handled by this class itself at
 	 * {@link #storePreDeleteOwnIdentityCommand(OwnIdentity)},
 	 * {@link #storePreDeleteIdentityCommand(Identity)} and
-	 * {@link #storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)}, there is no
-	 * need for outside classes to call it for that purpose directly. */
+	 * {@link #storePreRestoreOwnIdentityCommand(Identity)}, there is no need for outside classes to
+	 * call it for that purpose directly. */
 	@Override public void storeAbortFetchCommandWithoutCommit(Identity identity) {
 		Logger.normal(this, "storeAbortFetchCommandWithoutCommit(" + identity + ") ...");
 		
@@ -1102,6 +1102,13 @@ public final class IdentityDownloaderSlow implements
 			// consequence of Trusts and thus are also dealt with implicitly).
 			storeAbortFetchCommandWithoutCommit(oldIdentity);
 		}
+	}
+
+	@Override public void storePreRestoreOwnIdentityCommand(Identity oldIdentity) {
+		// Deletes all EditionHint objects it has received or given to other Identitys.
+		// Thus complies with our job of deleting all objects in the db4o database which point to
+		// the oldIdentity, as well as with aborting the download of it.
+		storeAbortFetchCommandWithoutCommit(oldIdentity);
 	}
 
 	/**

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -981,7 +981,8 @@ public final class IdentityDownloaderSlow implements
 	 * {@link EditionHint#getSourceIdentity()} or {@link EditionHint#getTargetIdentity()}.
 	 * 
 	 * Using this function for that purpose is handled by this class itself at
-	 * {@link #storePreDeleteOwnIdentityCommand(OwnIdentity)} and
+	 * {@link #storePreDeleteOwnIdentityCommand(OwnIdentity)},
+	 * {@link #storePreDeleteIdentityCommand(Identity)} and
 	 * {@link #storeRestoreOwnIdentityCommandWithoutCommit(Identity, OwnIdentity)}, there is no
 	 * need for outside classes to call it for that purpose directly. */
 	@Override public void storeAbortFetchCommandWithoutCommit(Identity identity) {
@@ -1066,7 +1067,9 @@ public final class IdentityDownloaderSlow implements
 		// Both stops the download of the Identity by deleting all EditionHint objects it has
 		// received as well as deleting all EditionHint objects it has given to other Identitys.
 		// Thus complies with our job of deleting all objects in the db4o database which point to
-		// the oldIdentity.
+		// the oldIdentity and those induced by the Scores it has given (in our case only by the
+		// given Trusts as we don't store anything due to Scores, but Scores are a consequence of
+		// Trusts and thus are also dealt with implicitly).
 		storeAbortFetchCommandWithoutCommit(oldIdentity);
 	}
 
@@ -1087,6 +1090,14 @@ public final class IdentityDownloaderSlow implements
 		}
 	}
 
+	@Override public void storePreDeleteIdentityCommand(Identity oldIdentity) {
+		// Both stops the download of the Identity by deleting all EditionHint objects it has
+		// received as well as deleting all EditionHint objects it has given to other Identitys.
+		// Thus complies with our job of deleting all objects in the db4o database which point to
+		// the oldIdentity and those induced by Trusts/Scores it has given/received (in our case
+		// only by the Trusts as we don't store anything due to Scores, but Scores are a consequence
+		// of Trusts and thus are also dealt with implicitly).
+		storeAbortFetchCommandWithoutCommit(oldIdentity);
 	}
 
 	/**

--- a/test/plugins/WebOfTrust/AbstractJUnit3BaseTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit3BaseTest.java
@@ -133,14 +133,19 @@ public class AbstractJUnit3BaseTest extends TestCase {
 					testClone(originalArray.getClass(), Array.get(originalArray, i), Array.get(clonedArray, i));
 				}
 			}
-				
 			
-			if(!field.getType().isEnum() // Enum objects exist only once
-				&& field.getType() != String.class // Strings are interned and therefore might also exist only once
-				&& !Modifier.isTransient(field.getModifiers())) // Persistent.mWebOfTurst/mDB are transient field which have the same value everywhere
+			// Check all fields for whether assertNotSame() applies to them, i.e. for whether the
+			// clone does not wrongly re-use objects of the original.
+			// Exclude fields for which using the same object would be safe.
+			if(    !field.getType().isPrimitive() // int etc. aren't objects. See testIsPrimitive().
+				&& !field.getType().isEnum() // Enum objects exist only once
+				&&  field.getType() != String.class // Strings are interned and therefore might also exist only once
+				&& !Modifier.isTransient(field.getModifiers()) // Persistent.mWebOfTurst/mDB are transient field which have the same value everywhere
+				&& !Modifier.isStatic(field.getModifiers()))
 			{
 				final Object originalField = field.get(original);
 				final Object clonedField = field.get(clone);
+				
 				if(originalField != null)
 					assertNotSame(field.toGenericString(), originalField, clonedField);
 				else
@@ -152,7 +157,37 @@ public class AbstractJUnit3BaseTest extends TestCase {
 		// We did check all fields manually already but we've got equals() so let's use it
 		assertEquals(original, clone);
 	}
-	
+
+	/**
+	 * Tests what we assume about {@link Class#isPrimitive()} assume at {@link #testClone(Class,
+	 * Object, Object)} because its documentation is a bit ambiguous:
+	 * isPrimitive() should only return true for types such as int, not for their wrapper classes
+	 * such as Integer.
+	 * @deprecated Use {@link AbstractJUnit4BaseTestSelfTest#testIsPrimitive()} */
+	@Deprecated
+	public static void testIsPrimitive() {
+		// Instead of accessing e.g. boolean.class directly wrap the primitives in classes to
+		// ensure we use the same codepath through class.getDeclaredFields() as testClone() does.
+		@SuppressWarnings("unused") class Primitives {
+			boolean a; byte b; char c;      short d; int f;     long g; float h; double i; };
+		@SuppressWarnings("unused") class NonPrimitives {
+			Boolean a; Byte b; Character c; Short d; Integer f; Long g; Float h; Double i; };
+		
+		for(Field f : Primitives.class.getDeclaredFields()) {
+			// Local classes cannot be static so ignore the pointer to the parent object.
+			if(f.getType() == AbstractJUnit3BaseTest.class)
+				continue;
+			
+			assertTrue(f.getType().isPrimitive());
+		}
+		for(Field f : NonPrimitives.class.getDeclaredFields()) {
+			if(f.getType() == AbstractJUnit3BaseTest.class)
+				continue;
+			
+			assertFalse(f.getType().isPrimitive());
+		}
+	}
+
 	/**
 	 * Generates a String containing random characters of the lowercase Latin alphabet.
 	 * @param The length of the returned string.

--- a/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
@@ -621,14 +621,19 @@ public abstract class AbstractJUnit4BaseTest {
 					testClone(originalArray.getClass(), Array.get(originalArray, i), Array.get(clonedArray, i));
 				}
 			}
-				
 			
-			if(!field.getType().isEnum() // Enum objects exist only once
-				&& field.getType() != String.class // Strings are interned and therefore might also exist only once
-				&& !Modifier.isTransient(field.getModifiers())) // Persistent.mWebOfTurst/mDB are transient field which have the same value everywhere
+			// Check all fields for whether assertNotSame() applies to them, i.e. for whether the
+			// clone does not wrongly re-use objects of the original.
+			// Exclude fields for which using the same object would be safe.
+			if(    !field.getType().isPrimitive() // int etc. aren't objects. See testIsPrimitive().
+				&& !field.getType().isEnum() // Enum objects exist only once
+				&&  field.getType() != String.class // Strings are interned and therefore might also exist only once
+				&& !Modifier.isTransient(field.getModifiers()) // Persistent.mWebOfTurst/mDB are transient field which have the same value everywhere
+				&& !Modifier.isStatic(field.getModifiers()))
 			{
 				final Object originalField = field.get(original);
 				final Object clonedField = field.get(clone);
+				
 				if(originalField != null)
 					assertNotSame(field.toGenericString(), originalField, clonedField);
 				else

--- a/test/plugins/WebOfTrust/AbstractJUnit4BaseTestSelfTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit4BaseTestSelfTest.java
@@ -4,8 +4,11 @@
 package plugins.WebOfTrust;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 
 import org.junit.Before;
@@ -56,5 +59,35 @@ public class AbstractJUnit4BaseTestSelfTest extends AbstractJUnit4BaseTest {
     @Override protected WebOfTrust getWebOfTrust() {
         return mWebOfTrust;
     }
+
+
+	/**
+	 * Tests what we assume about {@link Class#isPrimitive()} assume at {@link #testClone(Class,
+	 * Object, Object)} because its documentation is a bit ambiguous:
+	 * isPrimitive() should only return true for types such as int, not for their wrapper classes
+	 * such as Integer. */
+	@Test
+	public void testIsPrimitive() {
+		// Instead of accessing e.g. boolean.class directly wrap the primitives in classes to
+		// ensure we use the same codepath through class.getDeclaredFields() as testClone() does.
+		@SuppressWarnings("unused") class Primitives {
+			boolean a; byte b; char c;      short d; int f;     long g; float h; double i; };
+		@SuppressWarnings("unused") class NonPrimitives {
+			Boolean a; Byte b; Character c; Short d; Integer f; Long g; Float h; Double i; };
+		
+		for(Field f : Primitives.class.getDeclaredFields()) {
+			// Local classes cannot be static so ignore the pointer to the parent object.
+			if(f.getType() == AbstractJUnit4BaseTestSelfTest.class)
+				continue;
+			
+			assertTrue(f.getType().isPrimitive());
+		}
+		for(Field f : NonPrimitives.class.getDeclaredFields()) {
+			if(f.getType() == AbstractJUnit4BaseTestSelfTest.class)
+				continue;
+			
+			assertFalse(f.getType().isPrimitive());
+		}
+	}
 
 }

--- a/test/plugins/WebOfTrust/XMLTransformerTest.java
+++ b/test/plugins/WebOfTrust/XMLTransformerTest.java
@@ -118,7 +118,14 @@ public class XMLTransformerTest extends AbstractJUnit3BaseTest {
 							+ "</IdentityIntroduction>"
 							+ "</" + WebOfTrustInterface.WOT_NAME + ">";
 		
-		assertEquals(expectedXML, os.toString().replaceAll("[\n\r]", ""));
+		String withoutLineBreaks = os.toString().replaceAll("[\n\r]", "");
+		// Workaround for https://bugs.freenetproject.org/view.php?id=7017 while we cannot disable
+		// indentation in the XMLTransformer because it is needed as a workaround for
+		// https://bugs.freenetproject.org/view.php?id=4850 - once that issue is resolved and its
+		// workarounds have been removed please revert the commit which added this.
+		String withoutIndentation = withoutLineBreaks.replaceAll("    ", "");
+		
+		assertEquals(expectedXML, withoutIndentation);
 	}
 
 	public void testImportIntroduction() throws SAXException, IOException, InvalidParameterException {


### PR DESCRIPTION
_Please merge this into branch `issue-0003816-IdentityFetcher-rewrite` with `--ff-only`._
_This also contains the commits of the previous PRs to that branch. Merge those first to only see the relevant diff here._

---
