### PR TITLE
plot-download-stats part 1: Add plotting library XChart, compile it, speed up Ant by 1 minute to 12s

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="db4o-7.4/db4o.jar"/>
+	<classpathentry kind="lib" path="XChart/xchart.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fred"/>
 	<classpathentry kind="lib" path="/fred/lib/freenet/freenet-ext.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit4.jar"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 build-test
+dependencies
 dist
 override.properties

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "db4o-7.4"]
 	path = db4o-7.4
 	url = https://github.com/xor-freenet/db4o-7.4.git
+[submodule "XChart"]
+	path = XChart
+	url = https://github.com/xor-freenet/XChart

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 branches:
   except:
     - issue-0003816-IdentityFetcher-rewrite
+    - issue-0007021-plot-download-stats
 
 language: java
 

--- a/build.xml
+++ b/build.xml
@@ -131,22 +131,20 @@
 		</and>
 	</condition>
 
-	<target name="get-submodules" description="Downloads the git submodules required by WoT">
+	<target name="get-submodules" description="Downloads the git submodule dependencies required by WoT">
 		<echo>Downloading git submodules if they don't exist already...</echo>
 		<exec executable="git">
 			<arg line="submodule update --init"/>
 		</exec>
 	</target>
 
-	<target name="db4o" depends="get-submodules" description="Compiles the database submodule">
+	<target name="compile-submodules" depends="get-submodules" description="Compiles the dependencies">
 		<echo>Compiling db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" inheritAll="false" useNativeBasedir="true">
 			<property name="javac.source.version" value="${source-version}"/>
 			<property name="javac.target.version" value="${target-version}"/>
 		</ant>
-	</target>
-
-	<target name="xchart" depends="get-submodules" description="Compiles the plotting submodule">
+		
 		<echo>Compiling XChart submodule...</echo>
 		<ant dir="${xchart-submodule.location}" inheritAll="false" useNativeBasedir="true">
 			<property name="javac.source.version" value="${source-version}"/>
@@ -154,18 +152,15 @@
 		</ant>
 	</target>
 
-	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
+	<target name="clean-submodules" depends="get-submodules" description="Cleans the compile output of the dependencies">
 		<echo>Cleaning db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
-	</target>
-
-	<target name="clean-xchart" depends="get-submodules" description="Cleans the plotting submodule">
+		
 		<echo>Cleaning XChart submodule...</echo>
 		<ant dir="${xchart-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
 	</target>
-
 
 	<target name="print-libs">
 		<echo>External dependencies on classpath follow, but ONLY those which did exist.</echo>
@@ -191,7 +186,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="print-libs, db4o, xchart, mkdir">
+	<target name="compile" depends="print-libs, compile-submodules, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -437,7 +432,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" depends="clean-db4o, clean-xchart" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-submodules" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>

--- a/build.xml
+++ b/build.xml
@@ -41,9 +41,9 @@
 	<!-- Git submodule directories of dependencies. Will be compiled automatically! -->
 	<property name="db4o-submodule.location" location="db4o-7.4"/>
 	<property name="xchart-submodule.location" location="XChart"/>
-	<!-- JARs which the Ant builders of the submodules produce. -->
-	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
-	<property name="xchart.location" location="${xchart-submodule.location}/xchart.jar"/>
+	<!-- After compiling the submodule JARs are copied into this directory and used from there.
+	     (Copying is necessary because <zipgroupfileset> needs to consume a directory.) -->
+	<property name="dependencies.location" location="dependencies/"/>
 	<property name="svn.revision" value="@custom@"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
@@ -61,12 +61,10 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
-	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
-	<path id="submodules.path">
-		<pathelement location="${db4o.location}"/>
-		<pathelement location="${xchart.location}"/>
-	</path>
-	<!-- Libraries which we get from fred. -->
+	<!-- Libraries which we get from fred.
+	     TODO: Code quality: Copy them to dependencies.location and use them from there, delete them
+	     at clean task. This will allow compiling if fred isn't currently compiled as long as clean
+	     isn't run. -->
 	<path id="lib.path">
 		<!-- Use filesets instead of <pathelement> to:
 		     - allow using wildcards when including freenet.lib.new.location so we don't need to
@@ -82,6 +80,13 @@
 		<fileset file="${freenet.lib.old.location.3}" erroronmissingdir="no"/>
 		<fileset file="${freenet.lib.old.location.4}" erroronmissingdir="no"/>
 		<fileset file="${freenet.lib.old.location.5}" erroronmissingdir="no"/>
+	</path>
+
+	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
+	<path id="submodules.path">
+		<fileset dir="${dependencies.location}" erroronmissingdir="yes" casesensitive="no">
+			<include name="*.jar"/>
+		</fileset>
 	</path>
 
 	<path id="cobertura.path">
@@ -150,6 +155,9 @@
 			<property name="javac.source.version" value="${source-version}"/>
 			<property name="javac.target.version" value="${target-version}"/>
 		</ant>
+		
+		<copy file="${db4o-submodule.location}/db4o.jar" todir="${dependencies.location}" overwrite="true"/>
+		<copy file="${xchart-submodule.location}/xchart.jar" todir="${dependencies.location}" overwrite="true"/>
 	</target>
 
 	<target name="clean-submodules" depends="get-submodules" description="Cleans the compile output of the dependencies">
@@ -281,11 +289,7 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
-			<archives>
-				<zips>
-					<path refid="submodules.path"/>
-				</zips>
-			</archives>
+			<zipgroupfileset dir="${dependencies.location}" casesensitive="no" includes="*.jar"/>
 		</jar>
 	</target>
 
@@ -407,11 +411,7 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
-			<archives>
-				<zips>
-					<path refid="submodules.path"/>
-				</zips>
-			</archives>
+			<zipgroupfileset dir="${dependencies.location}" casesensitive="no" includes="*.jar"/>
 		</jar>
 	</target>
 
@@ -436,6 +436,7 @@
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>
+		<delete dir="${dependencies.location}"/>
 		<delete dir="${dist}"/>
 		<delete file="${debug-node-wot-plugin.location}"/>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -38,10 +38,12 @@
 	<!-- Configuration which you should probably leave as is!                                    -->
 	<!-- ======================================================================================= -->
 	
-	<!-- Git submodule directory of the db4o source code. Will be compiled automatically! -->
+	<!-- Git submodule directories of dependencies. Will be compiled automatically! -->
 	<property name="db4o-submodule.location" location="db4o-7.4"/>
-	<!-- JAR which the Ant builder of db4o produces. -->
+	<property name="xchart-submodule.location" location="XChart"/>
+	<!-- JARs which the Ant builders of the submodules produce. -->
 	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
+	<property name="xchart.location" location="${xchart-submodule.location}/xchart.jar"/>
 	<property name="svn.revision" value="@custom@"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
@@ -59,9 +61,10 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
-	<!-- Libraries whose classes are to be bundled in our own JAR. -->
+	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
 	<path id="submodules.path">
 		<pathelement location="${db4o.location}"/>
+		<pathelement location="${xchart.location}"/>
 	</path>
 	<!-- Libraries which we get from fred. -->
 	<path id="lib.path">
@@ -129,7 +132,7 @@
 	</condition>
 
 	<target name="get-submodules" description="Downloads the git submodules required by WoT">
-		<echo>Downloading db4o git submodule if it doesn't exist already...</echo>
+		<echo>Downloading git submodules if they don't exist already...</echo>
 		<exec executable="git">
 			<arg line="submodule update --init"/>
 		</exec>
@@ -143,9 +146,23 @@
 		</ant>
 	</target>
 
+	<target name="xchart" depends="get-submodules" description="Compiles the plotting submodule">
+		<echo>Compiling XChart submodule...</echo>
+		<ant dir="${xchart-submodule.location}" inheritAll="false" useNativeBasedir="true">
+			<property name="javac.source.version" value="${source-version}"/>
+			<property name="javac.target.version" value="${target-version}"/>
+		</ant>
+	</target>
+
 	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
 		<echo>Cleaning db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
+			useNativeBasedir="true"/>
+	</target>
+
+	<target name="clean-xchart" depends="get-submodules" description="Cleans the plotting submodule">
+		<echo>Cleaning XChart submodule...</echo>
+		<ant dir="${xchart-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
 	</target>
 
@@ -174,7 +191,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="print-libs, db4o, mkdir">
+	<target name="compile" depends="print-libs, db4o, xchart, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -269,9 +286,11 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
-			<zipfileset>
-				<path refid="submodules.path"/>
-			</zipfileset>
+			<archives>
+				<zips>
+					<path refid="submodules.path"/>
+				</zips>
+			</archives>
 		</jar>
 	</target>
 
@@ -330,6 +349,7 @@
 					<exclude name="**/TickerDelayedBackgroundJobTest.class"
 						unless="test.unreliable" />
 					<exclude name="com/db4o/**"/>
+					<exclude name="org/knowm/xchart/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -369,6 +389,7 @@
 					     constructor. -->
 					<exclude name="**/*$*.class"/>
 					<exclude name="com/db4o/**"/>
+					<exclude name="org/knowm/xchart/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -391,9 +412,11 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
-			<zipfileset>
-				<path refid="submodules.path"/>
-			</zipfileset>
+			<archives>
+				<zips>
+					<path refid="submodules.path"/>
+				</zips>
+			</archives>
 		</jar>
 	</target>
 
@@ -414,7 +437,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" depends="clean-db4o" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-db4o, clean-xchart" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>


### PR DESCRIPTION
_Please merge this into branch `issue-0007021-plot-download-stats` with `--ff-only`._

---

The library is pulled from a fork of it on my GitHub via a git submodule.

The fork differs from upstream by a minimal set of 5 commits of mine to:
- add an Ant builder instead of Maven.
- not ship much more code than needed by WoT = remove external dependencies of XChart.
- adapt the README to describe our usage of XChart.

As usual the git submodule hardcodes the used commit hash so I cannot add any further code without a new WoT commit explicitly showing that I've done so.

So if you review the five commits of mine leading up to that hash and validate the commit before them is from XChart then you've reviewed all code I could have added to the repository.