### PR TITLE
plot-download-stats part 13: Add differentiate(), use it to plot downloaded identity files per hour

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="db4o-7.4/db4o.jar"/>
+	<classpathentry kind="lib" path="XChart/xchart.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fred"/>
 	<classpathentry kind="lib" path="/fred/lib/freenet/freenet-ext.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit4.jar"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 build-test
+dependencies
 dist
 override.properties

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "db4o-7.4"]
 	path = db4o-7.4
 	url = https://github.com/xor-freenet/db4o-7.4.git
+[submodule "XChart"]
+	path = XChart
+	url = https://github.com/xor-freenet/XChart

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 branches:
   except:
     - issue-0003816-IdentityFetcher-rewrite
+    - issue-0007021-plot-download-stats
 
 language: java
 

--- a/build.xml
+++ b/build.xml
@@ -131,22 +131,20 @@
 		</and>
 	</condition>
 
-	<target name="get-submodules" description="Downloads the git submodules required by WoT">
+	<target name="get-submodules" description="Downloads the git submodule dependencies required by WoT">
 		<echo>Downloading git submodules if they don't exist already...</echo>
 		<exec executable="git">
 			<arg line="submodule update --init"/>
 		</exec>
 	</target>
 
-	<target name="db4o" depends="get-submodules" description="Compiles the database submodule">
+	<target name="compile-submodules" depends="get-submodules" description="Compiles the dependencies">
 		<echo>Compiling db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" inheritAll="false" useNativeBasedir="true">
 			<property name="javac.source.version" value="${source-version}"/>
 			<property name="javac.target.version" value="${target-version}"/>
 		</ant>
-	</target>
-
-	<target name="xchart" depends="get-submodules" description="Compiles the plotting submodule">
+		
 		<echo>Compiling XChart submodule...</echo>
 		<ant dir="${xchart-submodule.location}" inheritAll="false" useNativeBasedir="true">
 			<property name="javac.source.version" value="${source-version}"/>
@@ -154,18 +152,15 @@
 		</ant>
 	</target>
 
-	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
+	<target name="clean-submodules" depends="get-submodules" description="Cleans the compile output of the dependencies">
 		<echo>Cleaning db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
-	</target>
-
-	<target name="clean-xchart" depends="get-submodules" description="Cleans the plotting submodule">
+		
 		<echo>Cleaning XChart submodule...</echo>
 		<ant dir="${xchart-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
 	</target>
-
 
 	<target name="print-libs">
 		<echo>External dependencies on classpath follow, but ONLY those which did exist.</echo>
@@ -191,7 +186,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="print-libs, db4o, xchart, mkdir">
+	<target name="compile" depends="print-libs, compile-submodules, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -437,7 +432,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" depends="clean-db4o, clean-xchart" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-submodules" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>

--- a/build.xml
+++ b/build.xml
@@ -41,9 +41,9 @@
 	<!-- Git submodule directories of dependencies. Will be compiled automatically! -->
 	<property name="db4o-submodule.location" location="db4o-7.4"/>
 	<property name="xchart-submodule.location" location="XChart"/>
-	<!-- JARs which the Ant builders of the submodules produce. -->
-	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
-	<property name="xchart.location" location="${xchart-submodule.location}/xchart.jar"/>
+	<!-- After compiling the submodule JARs are copied into this directory and used from there.
+	     (Copying is necessary because <zipgroupfileset> needs to consume a directory.) -->
+	<property name="dependencies.location" location="dependencies/"/>
 	<property name="svn.revision" value="@custom@"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
@@ -61,12 +61,10 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
-	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
-	<path id="submodules.path">
-		<pathelement location="${db4o.location}"/>
-		<pathelement location="${xchart.location}"/>
-	</path>
-	<!-- Libraries which we get from fred. -->
+	<!-- Libraries which we get from fred.
+	     TODO: Code quality: Copy them to dependencies.location and use them from there, delete them
+	     at clean task. This will allow compiling if fred isn't currently compiled as long as clean
+	     isn't run. -->
 	<path id="lib.path">
 		<!-- Use filesets instead of <pathelement> to:
 		     - allow using wildcards when including freenet.lib.new.location so we don't need to
@@ -82,6 +80,13 @@
 		<fileset file="${freenet.lib.old.location.3}" erroronmissingdir="no"/>
 		<fileset file="${freenet.lib.old.location.4}" erroronmissingdir="no"/>
 		<fileset file="${freenet.lib.old.location.5}" erroronmissingdir="no"/>
+	</path>
+
+	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
+	<path id="submodules.path">
+		<fileset dir="${dependencies.location}" erroronmissingdir="yes" casesensitive="no">
+			<include name="*.jar"/>
+		</fileset>
 	</path>
 
 	<path id="cobertura.path">
@@ -150,6 +155,9 @@
 			<property name="javac.source.version" value="${source-version}"/>
 			<property name="javac.target.version" value="${target-version}"/>
 		</ant>
+		
+		<copy file="${db4o-submodule.location}/db4o.jar" todir="${dependencies.location}" overwrite="true"/>
+		<copy file="${xchart-submodule.location}/xchart.jar" todir="${dependencies.location}" overwrite="true"/>
 	</target>
 
 	<target name="clean-submodules" depends="get-submodules" description="Cleans the compile output of the dependencies">
@@ -281,11 +289,7 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
-			<archives>
-				<zips>
-					<path refid="submodules.path"/>
-				</zips>
-			</archives>
+			<zipgroupfileset dir="${dependencies.location}" casesensitive="no" includes="*.jar"/>
 		</jar>
 	</target>
 
@@ -407,11 +411,7 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
-			<archives>
-				<zips>
-					<path refid="submodules.path"/>
-				</zips>
-			</archives>
+			<zipgroupfileset dir="${dependencies.location}" casesensitive="no" includes="*.jar"/>
 		</jar>
 	</target>
 
@@ -436,6 +436,7 @@
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>
+		<delete dir="${dependencies.location}"/>
 		<delete dir="${dist}"/>
 		<delete file="${debug-node-wot-plugin.location}"/>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -38,10 +38,12 @@
 	<!-- Configuration which you should probably leave as is!                                    -->
 	<!-- ======================================================================================= -->
 	
-	<!-- Git submodule directory of the db4o source code. Will be compiled automatically! -->
+	<!-- Git submodule directories of dependencies. Will be compiled automatically! -->
 	<property name="db4o-submodule.location" location="db4o-7.4"/>
-	<!-- JAR which the Ant builder of db4o produces. -->
+	<property name="xchart-submodule.location" location="XChart"/>
+	<!-- JARs which the Ant builders of the submodules produce. -->
 	<property name="db4o.location" location="${db4o-submodule.location}/db4o.jar"/>
+	<property name="xchart.location" location="${xchart-submodule.location}/xchart.jar"/>
 	<property name="svn.revision" value="@custom@"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
@@ -59,9 +61,10 @@
 	<available file="${cobertura.location}" property="cobertura.present"/>
 	<property name="test.coverage" unless:set="${test.coverage}" if:true="${cobertura.present}" value="true"/>
 
-	<!-- Libraries whose classes are to be bundled in our own JAR. -->
+	<!-- Submodule libraries whose classes are to be bundled in our own JAR. -->
 	<path id="submodules.path">
 		<pathelement location="${db4o.location}"/>
+		<pathelement location="${xchart.location}"/>
 	</path>
 	<!-- Libraries which we get from fred. -->
 	<path id="lib.path">
@@ -129,7 +132,7 @@
 	</condition>
 
 	<target name="get-submodules" description="Downloads the git submodules required by WoT">
-		<echo>Downloading db4o git submodule if it doesn't exist already...</echo>
+		<echo>Downloading git submodules if they don't exist already...</echo>
 		<exec executable="git">
 			<arg line="submodule update --init"/>
 		</exec>
@@ -143,9 +146,23 @@
 		</ant>
 	</target>
 
+	<target name="xchart" depends="get-submodules" description="Compiles the plotting submodule">
+		<echo>Compiling XChart submodule...</echo>
+		<ant dir="${xchart-submodule.location}" inheritAll="false" useNativeBasedir="true">
+			<property name="javac.source.version" value="${source-version}"/>
+			<property name="javac.target.version" value="${target-version}"/>
+		</ant>
+	</target>
+
 	<target name="clean-db4o" depends="get-submodules" description="Cleans the database submodule">
 		<echo>Cleaning db4o submodule...</echo>
 		<ant dir="${db4o-submodule.location}" target="clean" inheritAll="false"
+			useNativeBasedir="true"/>
+	</target>
+
+	<target name="clean-xchart" depends="get-submodules" description="Cleans the plotting submodule">
+		<echo>Cleaning XChart submodule...</echo>
+		<ant dir="${xchart-submodule.location}" target="clean" inheritAll="false"
 			useNativeBasedir="true"/>
 	</target>
 
@@ -174,7 +191,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="compile" depends="print-libs, db4o, mkdir">
+	<target name="compile" depends="print-libs, db4o, xchart, mkdir">
 		<!-- Create the time stamp -->
 		<tstamp/>
 
@@ -269,9 +286,11 @@
 			</fileset>
 			
 			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
-			<zipfileset>
-				<path refid="submodules.path"/>
-			</zipfileset>
+			<archives>
+				<zips>
+					<path refid="submodules.path"/>
+				</zips>
+			</archives>
 		</jar>
 	</target>
 
@@ -330,6 +349,7 @@
 					<exclude name="**/TickerDelayedBackgroundJobTest.class"
 						unless="test.unreliable" />
 					<exclude name="com/db4o/**"/>
+					<exclude name="org/knowm/xchart/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -369,6 +389,7 @@
 					     constructor. -->
 					<exclude name="**/*$*.class"/>
 					<exclude name="com/db4o/**"/>
+					<exclude name="org/knowm/xchart/**"/>
 				</zipfileset>
 			</batchtest>
 			
@@ -391,9 +412,11 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			<fileset dir="${build}/"/>
-			<zipfileset>
-				<path refid="submodules.path"/>
-			</zipfileset>
+			<archives>
+				<zips>
+					<path refid="submodules.path"/>
+				</zips>
+			</archives>
 		</jar>
 	</target>
 
@@ -414,7 +437,7 @@
 	</target>
 
 	<!-- ================================================== -->
-	<target name="clean" depends="clean-db4o" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
+	<target name="clean" depends="clean-db4o, clean-xchart" description="Delete class files and docs dir and the plugin file in plugins/ of your debug node.">
 		<delete dir="${build}"/>
 		<delete dir="${build-test}"/>
 		<delete dir="${build-test-coverage}"/>

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -11,8 +11,10 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 import plugins.WebOfTrust.Identity.IdentityID;
+import plugins.WebOfTrust.util.Pair;
 import plugins.WebOfTrust.util.jobs.BackgroundJob;
 import freenet.keys.FreenetURI;
+import freenet.support.CurrentTimeUTC;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 
@@ -124,7 +126,14 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 			++mStatistics.mQueuedFiles;
 			++mStatistics.mTotalQueuedFiles;
 		}
-
+		
+		if(mStatistics.mTotalQueuedFiles > 0) {
+			// mTimesOfQueuing contains an initial entry for 0 files, which is wrong so remove it.
+			mStatistics.mTimesOfQueuing.clear();
+			mStatistics.mTimesOfQueuing.addLast(
+				new Pair<>(mStatistics.mStartupTimeMilliseconds, mStatistics.mTotalQueuedFiles));
+		}
+		
 		Logger.normal(this, "cleanDirectories(): Old queued files: " + mStatistics.mQueuedFiles);
 
 		// Processing dir policy:
@@ -197,6 +206,8 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 			// included: This ensures that the user might notice dropped files from the statistics
 			// in the UI.
 			++mStatistics.mTotalQueuedFiles;
+			mStatistics.mTimesOfQueuing.addLast(
+				new Pair<>(CurrentTimeUTC.getInMillis(), mStatistics.mTotalQueuedFiles));
 			
 			File filename = getQueueFilename(identityFileStream.mURI);
 			// Delete for deduplication

--- a/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
@@ -6,7 +6,9 @@ package plugins.WebOfTrust;
 import java.io.ByteArrayInputStream;
 import java.util.LinkedList;
 
+import freenet.support.CurrentTimeUTC;
 import freenet.support.Logger;
+import plugins.WebOfTrust.util.Pair;
 import plugins.WebOfTrust.util.jobs.BackgroundJob;
 
 /**
@@ -72,6 +74,8 @@ final class IdentityFileMemoryQueue implements IdentityFileQueue {
 			throw e;
 		} finally {
 			++mStatistics.mTotalQueuedFiles;
+			mStatistics.mTimesOfQueuing.addLast(
+				new Pair<>(CurrentTimeUTC.getInMillis(), mStatistics.mTotalQueuedFiles));
 			assert(checkConsistency());
 		}
 	}

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -119,8 +119,8 @@ public interface IdentityFileQueue {
 		 * = {@link #mTotalQueuedFiles}.
 		 * 
 		 * Additionally, for allowing external code to work without checks for emptiness, a first
-		 * Pair is added at construction to represent the initial amount of files at time of
-		 * construction, even if that amount is 0. */
+		 * Pair is added at construction to represent the initial amount of 0 files at time of
+		 * construction. */
 		public LimitedArrayDeque<Pair<Long, Integer>> mTimesOfQueuing
 			= new LimitedArrayDeque<>(MAX_TIMES_OF_QUEUING_SIZE);
 	
@@ -175,10 +175,6 @@ public interface IdentityFileQueue {
 	
 	
 		IdentityFileQueueStatistics() {
-			// FIXME: If files are left over from the previous session then mTotalQueuedFiles
-			// is currently initialized *after* this constructor by IdentityFileQueue
-			// implementations. Fix that code to pass it to this constructor instead so we use the
-			// right value here.
 			mTimesOfQueuing.addLast(new Pair<>(mStartupTimeMilliseconds, mTotalQueuedFiles));
 		}
 	

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -6,6 +6,7 @@ package plugins.WebOfTrust;
 import java.io.FilterInputStream;
 import java.io.InputStream;
 
+import plugins.WebOfTrust.network.input.IdentityDownloader;
 import plugins.WebOfTrust.util.LimitedArrayDeque;
 import plugins.WebOfTrust.util.Pair;
 import plugins.WebOfTrust.util.jobs.BackgroundJob;
@@ -102,21 +103,29 @@ public interface IdentityFileQueue {
 
 	public static final class IdentityFileQueueStatistics implements Cloneable {
 		/**
-		 * Count of files which were passed to {@link #add(IdentityFileStream)}.<br>
-		 * This <b>includes</b> files which:<br>
-		 * - are not queued anymore (see {@link #mFinishedFiles}).<br>
-		 * - are still queued (see {@link #mQueuedFiles}).<br>
-		 * - were deleted due to deduplication (see {@link #mDeduplicatedFiles}).<br>
-		 * - failed en-/dequeuing due to errors (see {@link #mFailedFiles}).<br><br>
+		 * Count of files which were passed to {@link #add(IdentityFileStream)}.
+		 * This is equal to the total number of downloaded Identity files as the contract of
+		 * {@link IdentityDownloader} specifies that strictly all downloaded files are passed to the
+		 * IdentityFileQueue.
+		 * 
+		 * Thus this includes files which:
+		 * - are not queued anymore (see {@link #mFinishedFiles}).
+		 * - are still queued (see {@link #mQueuedFiles}).
+		 * - were deleted due to deduplication (see {@link #mDeduplicatedFiles}).
+		 * - failed en-/dequeuing due to errors (see {@link #mFailedFiles}).
 		 * 
 		 * The lost files are included to ensure that errors can be noticed by the user from
-		 * statistics in the UI. */
+		 * statistics in the UI, and because this variable shall represent the total number of
+		 * downloaded files. */
 		public int mTotalQueuedFiles = 0;
 	
 		/**
 		 * For each queued file, i.e. each file part of {@link #mTotalQueuedFiles}, a {@link Pair}
 		 * is added with {@link Pair#x} = {@link CurrentTimeUTC#getInMillis()} and {@link Pair#y}
 		 * = {@link #mTotalQueuedFiles}.
+		 * 
+		 * Thus this contains the X/Y values for a plot of total downloaded Identity files across
+		 * the uptime of WoT.
 		 * 
 		 * Additionally, for allowing external code to work without checks for emptiness, a first
 		 * Pair is added at construction to represent the initial amount of 0 files at time of

--- a/src/plugins/WebOfTrust/l10n/lang_de.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_de.l10n
@@ -180,6 +180,9 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Insgesamt eingefügte (= he
 StatisticsPage.MaintenanceBox.Header=Wartung
 StatisticsPage.MaintenanceBox.LastDefrag=Letzte Defragmentierung der Datenbank: ${lastTime} (Zeitplan: alle ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Letzte Überprüfung der inkrementell berechneten Vertrauenswerte: ${lastTime} (Zeitplan: alle ${interval})
+StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Insgesamt heruntergeladene Identitäts-Dateien
+StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minuten
+StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Dateien
 StatisticsPage.SummaryBox.EventNotifications.Pending=Ereignismeldungen in der Versand-Warteschlange: ${amount}
 StatisticsPage.SummaryBox.EventNotifications.Total=Gesamtzahl der jemals erstellten Ereignismeldungen (nur für aktuelle Clients): ${amount}
 StatisticsPage.SummaryBox.FetchProgress=Summe aller Editionsnummern: ${editionCount}

--- a/src/plugins/WebOfTrust/l10n/lang_de.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_de.l10n
@@ -182,6 +182,7 @@ StatisticsPage.MaintenanceBox.LastDefrag=Letzte Defragmentierung der Datenbank: 
 StatisticsPage.MaintenanceBox.LastScoreVerification=Letzte Überprüfung der inkrementell berechneten Vertrauenswerte: ${lastTime} (Zeitplan: alle ${interval})
 StatisticsPage.PlotBox.Header=Graphen
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Insgesamt heruntergeladene Identitäts-Dateien
+StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Hours=Stunden
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minuten
 StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Dateien
 StatisticsPage.SummaryBox.EventNotifications.Pending=Ereignismeldungen in der Versand-Warteschlange: ${amount}

--- a/src/plugins/WebOfTrust/l10n/lang_de.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_de.l10n
@@ -180,6 +180,7 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Insgesamt eingefügte (= he
 StatisticsPage.MaintenanceBox.Header=Wartung
 StatisticsPage.MaintenanceBox.LastDefrag=Letzte Defragmentierung der Datenbank: ${lastTime} (Zeitplan: alle ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Letzte Überprüfung der inkrementell berechneten Vertrauenswerte: ${lastTime} (Zeitplan: alle ${interval})
+StatisticsPage.PlotBox.Header=Graphen
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Insgesamt heruntergeladene Identitäts-Dateien
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minuten
 StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Dateien

--- a/src/plugins/WebOfTrust/l10n/lang_de.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_de.l10n
@@ -180,6 +180,10 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Insgesamt eingefügte (= he
 StatisticsPage.MaintenanceBox.Header=Wartung
 StatisticsPage.MaintenanceBox.LastDefrag=Letzte Defragmentierung der Datenbank: ${lastTime} (Zeitplan: alle ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Letzte Überprüfung der inkrementell berechneten Vertrauenswerte: ${lastTime} (Zeitplan: alle ${interval})
+StatisticsPage.PlotBox.DownloadsPerHourPlot.Title=Pro Stunde heruntergeladene Identitäts-Dateien
+StatisticsPage.PlotBox.DownloadsPerHourPlot.XAxis.Hours=Stunden
+StatisticsPage.PlotBox.DownloadsPerHourPlot.XAxis.Minutes=Minuten
+StatisticsPage.PlotBox.DownloadsPerHourPlot.YAxis=Dateien pro Stunde
 StatisticsPage.PlotBox.Header=Graphen
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Insgesamt heruntergeladene Identitäts-Dateien
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Hours=Stunden

--- a/src/plugins/WebOfTrust/l10n/lang_en.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_en.l10n
@@ -180,6 +180,10 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Total ever enqueued (= down
 StatisticsPage.MaintenanceBox.Header=Maintenance
 StatisticsPage.MaintenanceBox.LastDefrag=Last defragmentation of database: ${lastTime} (schedule: every ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Last verification of incrementally computed trust values: ${lastTime} (schedule: every ${interval})
+StatisticsPage.PlotBox.DownloadsPerHourPlot.Title=Identity files downloaded per hour
+StatisticsPage.PlotBox.DownloadsPerHourPlot.XAxis.Hours=Hours
+StatisticsPage.PlotBox.DownloadsPerHourPlot.XAxis.Minutes=Minutes
+StatisticsPage.PlotBox.DownloadsPerHourPlot.YAxis=Files per hour
 StatisticsPage.PlotBox.Header=Graphs
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Total downloaded identity files
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Hours=Hours

--- a/src/plugins/WebOfTrust/l10n/lang_en.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_en.l10n
@@ -180,6 +180,7 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Total ever enqueued (= down
 StatisticsPage.MaintenanceBox.Header=Maintenance
 StatisticsPage.MaintenanceBox.LastDefrag=Last defragmentation of database: ${lastTime} (schedule: every ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Last verification of incrementally computed trust values: ${lastTime} (schedule: every ${interval})
+StatisticsPage.PlotBox.Header=Graphs
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Total downloaded identity files
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minutes
 StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Files

--- a/src/plugins/WebOfTrust/l10n/lang_en.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_en.l10n
@@ -180,6 +180,9 @@ StatisticsPage.IdentityFileQueueBox.TotalQueuedFiles=Total ever enqueued (= down
 StatisticsPage.MaintenanceBox.Header=Maintenance
 StatisticsPage.MaintenanceBox.LastDefrag=Last defragmentation of database: ${lastTime} (schedule: every ${interval})
 StatisticsPage.MaintenanceBox.LastScoreVerification=Last verification of incrementally computed trust values: ${lastTime} (schedule: every ${interval})
+StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Total downloaded identity files
+StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minutes
+StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Files
 StatisticsPage.SummaryBox.EventNotifications.Pending=Event notifications queued for sending: ${amount}
 StatisticsPage.SummaryBox.EventNotifications.Total=Total event notifications ever created (only for current clients): ${amount}
 StatisticsPage.SummaryBox.FetchProgress=Sum of all edition numbers: ${editionCount}

--- a/src/plugins/WebOfTrust/l10n/lang_en.l10n
+++ b/src/plugins/WebOfTrust/l10n/lang_en.l10n
@@ -182,6 +182,7 @@ StatisticsPage.MaintenanceBox.LastDefrag=Last defragmentation of database: ${las
 StatisticsPage.MaintenanceBox.LastScoreVerification=Last verification of incrementally computed trust values: ${lastTime} (schedule: every ${interval})
 StatisticsPage.PlotBox.Header=Graphs
 StatisticsPage.PlotBox.TotalDownloadCountPlot.Title=Total downloaded identity files
+StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Hours=Hours
 StatisticsPage.PlotBox.TotalDownloadCountPlot.XAxis.Minutes=Minutes
 StatisticsPage.PlotBox.TotalDownloadCountPlot.YAxis=Files
 StatisticsPage.SummaryBox.EventNotifications.Pending=Event notifications queued for sending: ${amount}

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -20,8 +20,8 @@ import freenet.keys.FreenetURI;
 
 /**
  * Downloads {@link Identity} objects from the P2P network.
- * They are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which is consumed by
- * the {@link IdentityFileProcessor}.
+ * Strictly all of them are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which
+ * is consumed by the {@link IdentityFileProcessor}.
  * 
  * Implementations are allowed to and do store pointers to {@link Identity} and {@link OwnIdentity}
  * objects in their database, e.g. as part of {@link EditionHint} objects and

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -123,12 +123,8 @@ public class StatisticsPage extends WebPageImpl {
 
 	private void makePlotBox() {
 		HTMLNode box = addContentBox(l10n().getString("StatisticsPage.PlotBox.Header"));
-		box.addChild("img", "src", getTotalDownloadCountImageURI().toString());
-	}
-
-	private URI getTotalDownloadCountImageURI() {
-		return ((StatisticsPNGWebInterfaceToadlet)mWebInterface.getToadlet(StatisticsPNGWebInterfaceToadlet.class))
-		         .getURI(StatisticsType.TotalDownloadCount);
+		for(StatisticsType type : StatisticsType.values())
+			box.addChild("img", "src", type.getURI(mWebInterface).toString());
 	}
 
 	/**
@@ -315,10 +311,17 @@ public class StatisticsPage extends WebPageImpl {
 	}
 
 	/**
-	 * Each value of this enum defines a {@link StatisticsPNGRenderer#getPNG(WebOfTrust)} to
-	 * render the associated statistics plot.
-	 * The values can be passed to {@link StatisticsPNGWebInterfaceToadlet#getURI()} to obtain
-	 * their image's URI. FIXME: Add URI getter to StatisticsPNGRenderer. */
+	 * Each value of this enum defines a {@link StatisticsPNGRenderer#getPNG(WebOfTrust)} to render
+	 * the associated statistics plot.
+	 * 
+	 * The PNG images of all values of this enum will automatically be served by
+	 * {@link StatisticsPNGWebInterfaceToadlet} at the URI as obtainable by
+	 * {@link #getURI(WebInterface)}.
+	 * All images are automatically added to the HTML of the StatisticsPage, using that URI, by
+	 * {@link StatisticsPage#makePlotBox()}.
+	 * 
+	 * Thus to add a new type of statistics all you have to do is add a new value to this enum with
+	 * the associated {@link StatisticsPNGRenderer} passed to its constructor. */
 	public static enum StatisticsType implements StatisticsPNGRenderer {
 		TotalDownloadCount(new StatisticsPNGRenderer() {
 			/**
@@ -388,6 +391,15 @@ public class StatisticsPage extends WebPageImpl {
 		 * https://stackoverflow.com/a/50472201 */
 		@Override public byte[] getPNG(WebOfTrust wot) {
 			return mRenderer.getPNG(wot);
+		}
+
+		/** Returns the URI of the PNG image of this StatisticsType as served by the
+		 *  {@link StatisticsPNGWebInterfaceToadlet}. */
+		public URI getURI(WebInterface wi) {
+			StatisticsPNGWebInterfaceToadlet myToadlet = (StatisticsPNGWebInterfaceToadlet)
+				wi.getToadlet(StatisticsPNGWebInterfaceToadlet.class);
+			
+			return myToadlet.getURI(this);
 		}
 	}
 

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -345,6 +345,7 @@ public class StatisticsPage extends WebPageImpl {
 				// timesOfQueuing is safe to be fed into this:
 				// - getStatistics() returns a clone() so it may be modified.
 				// - IdentityFileQueueStatistics specifies it to always contain at least one entry.
+				// FIXME: Move l.getString() to getTimeBasedPlotPNG()
 				return getTimeBasedPlotPNG(timesOfQueuing, x0,
 					l.getString(p + "Title"), l.getString(p + "XAxis.Hours"), 
 					l.getString(p + "XAxis.Minutes") , l.getString(p + "YAxis"));

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -5,16 +5,24 @@ package plugins.WebOfTrust.ui.web;
 
 import static freenet.support.TimeUtil.formatTime;
 import static java.lang.Math.max;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static plugins.WebOfTrust.Configuration.DEFAULT_DEFRAG_INTERVAL;
 import static plugins.WebOfTrust.Configuration.DEFAULT_VERIFY_SCORES_INTERVAL;
 import static plugins.WebOfTrust.ui.web.CommonWebUtils.formatTimeDelta;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.QuickChart;
+import org.knowm.xchart.XYChart;
+
 import plugins.WebOfTrust.Configuration;
 import plugins.WebOfTrust.Identity;
+import plugins.WebOfTrust.IdentityFile;
 import plugins.WebOfTrust.IdentityFileProcessor;
 import plugins.WebOfTrust.IdentityFileQueue.IdentityFileQueueStatistics;
 import plugins.WebOfTrust.SubscriptionManager;
@@ -25,6 +33,8 @@ import plugins.WebOfTrust.network.input.IdentityDownloaderFast;
 import plugins.WebOfTrust.network.input.IdentityDownloaderFast.IdentityDownloaderFastStatistics;
 import plugins.WebOfTrust.network.input.IdentityDownloaderSlow;
 import plugins.WebOfTrust.network.input.IdentityDownloaderSlow.IdentityDownloaderSlowStatistics;
+import plugins.WebOfTrust.util.LimitedArrayDeque;
+import plugins.WebOfTrust.util.Pair;
 import freenet.clients.http.ToadletContext;
 import freenet.l10n.BaseL10n;
 import freenet.support.CurrentTimeUTC;
@@ -285,6 +295,58 @@ public class StatisticsPage extends WebPageImpl {
 			+ " " + stats.mFailedFiles));
 		
 		box.addChild(list);
+	}
+
+	/**
+	 * Renders a chart where the X-axis is the uptime of WoT, and the Y-axis is the total number of
+	 * downloaded {@link IdentityFile}s.
+	 * 
+	 * @see IdentityFileQueueStatistics#mTotalQueuedFiles
+	 * @see IdentityFileQueueStatistics#mTimesOfQueuing */
+	public static byte[] getTotalDownloadCountPlotPNG(WebOfTrust wot) {
+		IdentityFileQueueStatistics stats = wot.getIdentityFileQueue().getStatistics();
+		LimitedArrayDeque<Pair<Long, Integer>> timesOfQueuing
+			= stats.mTimesOfQueuing;
+		
+		// Add a dummy entry for the current time to the end of the plot so refreshing the image
+		// periodically shows that it is live even when there is no progress.
+		// Adding it to the obtained statistics is fine as they are a clone() of the original.
+		// Also peekLast() can never return null because mTimesOfQueuing by contract always contains
+		// at least one element.
+		timesOfQueuing.addLast(
+			new Pair<>(CurrentTimeUTC.getInMillis(), timesOfQueuing.peekLast().y));
+		
+		long x0 = stats.mStartupTimeMilliseconds;
+		double[] x = new double[timesOfQueuing.size()];
+		double[] y = new double[x.length];
+		int i = 0;
+		for(Pair<Long, Integer> p : timesOfQueuing) {
+			// FIXME: Switch to hours for large ranges of the plot
+			x[i] = ((double)(p.x - x0)) / (double)MINUTES.toMillis(1);
+			y[i] = p.y;
+			++i;
+		}
+		
+		BaseL10n l = wot.getBaseL10n();
+		String p = "StatisticsPage.PlotBox.TotalDownloadCountPlot.";
+		XYChart c = QuickChart.getChart(l.getString(p + "Title"), l.getString(p + "XAxis.Minutes"),
+			l.getString(p + "YAxis"), null, x, y);
+		
+		/* For debugging
+		for(XYSeries s: c.getSeriesMap().values())
+			s.setMarker(SeriesMarkers.CIRCLE);
+		*/
+		
+		byte[] png;
+		try {
+			png = BitmapEncoder.getBitmapBytes(c, BitmapFormat.PNG);
+		} catch (IOException e) {
+			// No idea why this would happen so don't require callers to handle it by converting
+			// to non-declared exception.
+			throw new RuntimeException(e);
+		}
+		
+		return png;
 	}
 
 	private void makeIdentityFileProcessorBox() {

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -5,9 +5,11 @@ package plugins.WebOfTrust.ui.web;
 
 import static freenet.support.TimeUtil.formatTime;
 import static java.lang.Math.max;
+import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static plugins.WebOfTrust.Configuration.DEFAULT_DEFRAG_INTERVAL;
 import static plugins.WebOfTrust.Configuration.DEFAULT_VERIFY_SCORES_INTERVAL;
 import static plugins.WebOfTrust.ui.web.CommonWebUtils.formatTimeDelta;
@@ -415,6 +417,83 @@ public class StatisticsPage extends WebPageImpl {
 			}
 			
 			return png;
+		}
+
+		/**
+		 * Input:
+		 * - a {@link LimitedArrayDeque} of {@link Pair}s where {@link Pair#x} is a
+		 *   {@link CurrentTimeUTC#getInMillis()} timestamp and {@link Pair#y}
+		 *   is an arbitrary {@link Number} which supports {@link Number#doubleValue()}.
+		 *   This can be interpreted as a series of measurements which shall be preprocessed by this
+		 *   function in order to later on create an {@link XYChart}.
+		 * - an integer threshold of seconds.
+		 * 
+		 * Output:
+		 * A new LimitedArrayDeque is returned where each contained Pair contains the average X- and
+		 * Y-values of the Pairs in the source dataset across the given amount of seconds.
+		 * I.e. it splits the given dataset into slots of the given amount of seconds, builds
+		 * the average X/Y-value across those slots, and for each slot returns a single Pair.
+		 * 
+		 * If a slot contains less than 16 Pairs it is extended until it contains at least 16.
+		 * I.e. a single result slot must contain the average of at least 16 Pairs.
+		 * This is done in order to prevent the resulting plot from being jumpy in areas of few
+		 * measurements.
+		 * 
+		 * If there aren't even 16 measurements in the input dataset the result is not empty, a
+		 * single Pair is returned to contain the average of the given data.
+		 * This ensures code which processes the result does not have to contain code for handling
+		 * emptiness if the input data is never empty. */
+		public static final <T extends Number> LimitedArrayDeque<Pair<Long, Double>> average(
+				LimitedArrayDeque<Pair<Long, T>> xyData, int seconds) {
+			
+			assert(xyData.size() > 0);
+			assert(seconds > 0);
+			
+			LimitedArrayDeque<Pair<Long, Double>> result
+				= new LimitedArrayDeque<>(xyData.sizeLimit());
+			
+			if(xyData.size() < 2)
+				return result;
+			
+			Pair<Long, T> startOfAverage = xyData.peekFirst();
+			double xAverage = 0;
+			double yAverage = 0;
+			int amount = 0;
+			for(Pair<Long, T> cur : xyData) {
+				if((cur.x - startOfAverage.x) <= SECONDS.toMillis(seconds) || amount < 16) {
+					// Undo previous averaging
+					xAverage *= amount;
+					yAverage *= amount;
+
+					// Compute new average. We must divide at every added item instead of only
+					// dividing after the last because the values may be so large that they cause
+					// overflow or imprecision if we keep adding them up until the end.
+					xAverage += cur.x.doubleValue();
+					yAverage += cur.y.doubleValue();
+					++amount;
+					xAverage /= amount;
+					yAverage /= amount;
+				} else {
+					assert(xAverage <= (startOfAverage.x + SECONDS.toMillis(seconds))
+						|| amount == 16);
+					
+					result.addLast(new Pair<>(round(xAverage), yAverage));
+					
+					startOfAverage = cur;
+					xAverage = 0;
+					yAverage = 0;
+					amount = 0;
+				}
+			}
+			
+			// If there is remaining data add it to the result if it contains at least the minimum
+			// amount of measurements.
+			// But if the result set is empty then ignore the minimum amount so we never return an
+			// empty result.
+			if(amount >= 16 || result.size() == 0)
+				result.addLast(new Pair<>(round(xAverage), yAverage));
+			
+			return result;
 		}
 
 		private final StatisticsPNGRenderer mRenderer;

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -354,7 +354,7 @@ public class StatisticsPage extends WebPageImpl {
 		 * 
 		 * @param xyData The plot data. A {@link LimitedArrayDeque} of {@link Pair}s where
 		 *     {@link Pair#x} is a {@link CurrentTimeUTC#getInMillis()} timestamp and {@link Pair#y}
-		 *     is an arbitrary integer.
+		 *     is an arbitrary {@link Number} which supports {@link Number#doubleValue()}.
 		 *     ATTENTION: This object MUST be safe to modify by this function!
 		 *     It MUST always contain at least one entry.
 		 * @param x0 The {@link CurrentTimeUTC#getInMillis()} of the x=0 origin of the plot. The
@@ -368,8 +368,8 @@ public class StatisticsPage extends WebPageImpl {
 		 *     display minutes.
 		 * @param yLabel L10n key of the Y-axis label.
 		 * @return An image of the PNG format, serialized to a byte array. */
-		public static final byte[] getTimeBasedPlotPNG(
-				LimitedArrayDeque<Pair<Long, Integer>> xyData, long x0, BaseL10n l10n,
+		public static final <T extends Number> byte[] getTimeBasedPlotPNG(
+				LimitedArrayDeque<Pair<Long, T>> xyData, long x0, BaseL10n l10n,
 				String title, String xLabelHours, String xLabelMinutes, String yLabel) {
 			
 			// Add a dummy entry for the current time to the end of the plot so refreshing the image
@@ -390,9 +390,9 @@ public class StatisticsPage extends WebPageImpl {
 			double[] x = new double[xyData.size()];
 			double[] y = new double[x.length];
 			int i = 0;
-			for(Pair<Long, Integer> p : xyData) {
+			for(Pair<Long, T> p : xyData) {
 				x[i] = ((double)(p.x - x0)) / timeUnit;
-				y[i] = p.y;
+				y[i] = p.y.doubleValue();
 				++i;
 			}
 			

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -11,6 +11,7 @@ import static plugins.WebOfTrust.Configuration.DEFAULT_VERIFY_SCORES_INTERVAL;
 import static plugins.WebOfTrust.ui.web.CommonWebUtils.formatTimeDelta;
 
 import java.io.IOException;
+import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +34,8 @@ import plugins.WebOfTrust.network.input.IdentityDownloaderFast;
 import plugins.WebOfTrust.network.input.IdentityDownloaderFast.IdentityDownloaderFastStatistics;
 import plugins.WebOfTrust.network.input.IdentityDownloaderSlow;
 import plugins.WebOfTrust.network.input.IdentityDownloaderSlow.IdentityDownloaderSlowStatistics;
+import plugins.WebOfTrust.ui.web.WebInterface.StatisticsPNGWebInterfaceToadlet;
+import plugins.WebOfTrust.ui.web.WebInterface.StatisticsType;
 import plugins.WebOfTrust.util.LimitedArrayDeque;
 import plugins.WebOfTrust.util.Pair;
 import freenet.clients.http.ToadletContext;
@@ -63,6 +66,7 @@ public class StatisticsPage extends WebPageImpl {
 	@Override
 	public void make(final boolean mayWrite) {
 		makeSummary();
+		makePlotBox();
 		makeIdentityDownloaderFastBox();
 		makeIdentityDownloaderSlowBox();
 		makeIdentityDownloaderSlowQueueBox();
@@ -116,6 +120,16 @@ public class StatisticsPage extends WebPageImpl {
 		}
 		
 		box.addChild(list);
+	}
+
+	private void makePlotBox() {
+		HTMLNode box = addContentBox(l10n().getString("StatisticsPage.PlotBox.Header"));
+		box.addChild("img", "src", getTotalDownloadCountImageURI().toString());
+	}
+
+	private URI getTotalDownloadCountImageURI() {
+		return ((StatisticsPNGWebInterfaceToadlet)mWebInterface.getToadlet(StatisticsPNGWebInterfaceToadlet.class))
+		         .getURI(StatisticsType.TotalDownloadCount);
 	}
 
 	/**

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -352,6 +352,40 @@ public class StatisticsPage extends WebPageImpl {
 				return getTimeBasedPlotPNG(timesOfQueuing, x0, wot.getBaseL10n(), l10n + "Title", 
 					l10n + "XAxis.Hours",  l10n + "XAxis.Minutes", l10n + "YAxis");
 			}
+		}),
+		DownloadsPerHour(new StatisticsPNGRenderer() {
+			/**
+			 * Renders a chart where the X-axis is the uptime of WoT, and the Y-axis is the number
+			 * of downloaded {@link IdentityFile}s per hour.
+			 * This is calculated by differentiating the total download count.
+			 * 
+			 * @see IdentityFileQueueStatistics#mTotalQueuedFiles
+			 * @see IdentityFileQueueStatistics#mTimesOfQueuing */
+			@Override public byte[] getPNG(WebOfTrust wot) {
+				IdentityFileQueueStatistics stats = wot.getIdentityFileQueue().getStatistics();
+				Long x0 = stats.mStartupTimeMilliseconds;
+				LimitedArrayDeque<Pair<Long, Integer>> timesOfQueuing
+					= stats.mTimesOfQueuing;
+				String l10n = "StatisticsPage.PlotBox.DownloadsPerHourPlot.";
+				
+				// FIXME: Add first/last value to input data which produces desirable results.
+				// Change getTimeBasedPlotPNG() to not add the trailing element which it added
+				// for purposes of TotalDownloadCount, that one should do it itself as it doesn't
+				// necessarily make sense for our plot here.
+				
+				// - Build the average before differentiating to prevent a jumpy graph due to
+				//   fred delivering batches of many files at once for internal reasons.
+				//   FIXME: Use a moving average to make the graph less coarse.
+				// - Convert to hours before differentiating to aid the "dy/dx" division in
+				//   preserving floating point accuracy.
+				//   FIXME: Convert the input dataset from milliseconds to seconds before to
+				//   preserve even more accuracy. We likely won't need milliseconds for any plot.
+				LimitedArrayDeque<Pair<Long, Double>> downloadsPerHour
+					= differentiate(multiplyY(average(timesOfQueuing, 10), HOURS.toMillis(1)));
+				
+				return getTimeBasedPlotPNG(downloadsPerHour, x0, wot.getBaseL10n(), l10n + "Title", 
+					l10n + "XAxis.Hours",  l10n + "XAxis.Minutes", l10n + "YAxis");
+			}
 		});
 
 		/**

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -4,6 +4,9 @@
 package plugins.WebOfTrust.ui.web;
 
 import static freenet.support.TimeUtil.formatTime;
+import static java.lang.Double.isInfinite;
+import static java.lang.Double.isNaN;
+import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -18,6 +21,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
 import org.knowm.xchart.BitmapEncoder;
@@ -508,6 +512,51 @@ public class StatisticsPage extends WebPageImpl {
 		
 			for(Pair<Long, T> cur : xyData)
 				result.addLast(new Pair<>(cur.x, cur.y.doubleValue() * multiplier));
+			
+			return result;
+		}
+
+		/**
+		 * Consumes a {@link LimitedArrayDeque} of {@link Pair}s where {@link Pair#x} is a
+		 * {@link CurrentTimeUTC#getInMillis()} timestamp and {@link Pair#y}
+		 * is an arbitrary {@link Number} which supports {@link Number#doubleValue()}.
+		 * This can be interpreted as a series of measurements which shall be preprocessed by this
+		 * function in order to later on create an {@link XYChart}.
+		 * 
+		 * Returns a new LimitedArrayDeque which contains the dy/dx of the given plot data.
+		 * 
+		 * The resulting dataset will be smaller than the input. */
+		public static final <T extends Number> LimitedArrayDeque<Pair<Long, Double>> differentiate(
+				LimitedArrayDeque<Pair<Long, T>> xyData) {
+			
+			assert(xyData.size() >= 2);
+			
+			LimitedArrayDeque<Pair<Long, Double>> result =
+				new LimitedArrayDeque<>(xyData.sizeLimit());
+			
+			if(xyData.size() < 2)
+				return result;
+			
+			Iterator<Pair<Long, T>> i = xyData.iterator();
+			Pair<Long, T> prev = i.next();			
+			do {
+				Pair<Long, T> cur = i.next();
+				
+				long  dx = cur.x - prev.x;
+				// Avoid division by zero in dy/dx.
+				if(abs(dx) <= Double.MIN_VALUE)
+					continue;
+				
+				double dy = cur.y.doubleValue() - prev.y.doubleValue();
+				
+				Long   x = prev.x;
+				double y = dy / dx;
+				
+				assert(!isInfinite(y) && !isNaN(y)) : "Division by zero!";
+				
+				result.addLast(new Pair<>(x, y));
+				prev = cur;
+			} while(i.hasNext());
 			
 			return result;
 		}

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -496,6 +496,22 @@ public class StatisticsPage extends WebPageImpl {
 			return result;
 		}
 
+		/**
+		 * Returns a new {@link LimitedArrayDeque} with new {@link Pair} objects where each Pair's
+		 * {@link Number#doubleValue()} of the {@link Pair#y} is multiplied by the given
+		 * multiplier. r*/
+		public static final <T extends Number> LimitedArrayDeque<Pair<Long, Double>> multiplyY(
+				LimitedArrayDeque<Pair<Long, T>> xyData, long multiplier) {
+			
+			LimitedArrayDeque<Pair<Long, Double>> result
+				= new LimitedArrayDeque<>(xyData.sizeLimit());
+		
+			for(Pair<Long, T> cur : xyData)
+				result.addLast(new Pair<>(cur.x, cur.y.doubleValue() * multiplier));
+			
+			return result;
+		}
+
 		private final StatisticsPNGRenderer mRenderer;
 	
 		private StatisticsType(StatisticsPNGRenderer r) {

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -372,50 +372,50 @@ public class StatisticsPage extends WebPageImpl {
 				LimitedArrayDeque<Pair<Long, Integer>> xyData, long x0,
 				String title, String xLabelHours, String xLabelMinutes, String yLabel) {
 			
-				// Add a dummy entry for the current time to the end of the plot so refreshing the
-				// image periodically shows that it is live even when there is no progress.
-				xyData.addLast(
-					new Pair<>(CurrentTimeUTC.getInMillis(), xyData.peekLast().y));
+			// Add a dummy entry for the current time to the end of the plot so refreshing the image
+			// periodically shows that it is live even when there is no progress.
+			xyData.addLast(
+				new Pair<>(CurrentTimeUTC.getInMillis(), xyData.peekLast().y));
 			
-				// If the amount of measurements we've gathered is at least 2 hours then we measure
-				// the X-axis in hours, otherwise we measure it in minutes.
-				// Using 2 hours instead of the more natural 1 hour because 1 hour measurements are
-				// a typical benchmark of bootstrapping and I don't want to annoy people who want
-				// to measure that with the X-axis not showing minutes.
-				boolean hours = MILLISECONDS.toHours(
-						(xyData.peekLast().x - xyData.peekFirst().x)
-					) >= 2;
-				
-				double timeUnit = (hours ? HOURS : MINUTES).toMillis(1);
-				double[] x = new double[xyData.size()];
-				double[] y = new double[x.length];
-				int i = 0;
-				for(Pair<Long, Integer> p : xyData) {
-					x[i] = ((double)(p.x - x0)) / timeUnit;
-					y[i] = p.y;
-					++i;
-				}
-				
-				XYChart c = QuickChart.getChart(title, (hours ? xLabelHours : xLabelMinutes),
-					yLabel, null, x, y);
-				
-				/* For debugging
+			// If the amount of measurements we've gathered is at least 2 hours then we measure the
+			// X-axis in hours, otherwise we measure it in minutes.
+			// Using 2 hours instead of the more natural 1 hour because 1 hour measurements are a
+			// typical benchmark of bootstrapping and I don't want to annoy people who want to
+			// measure that with the X-axis not showing minutes.
+			boolean hours = MILLISECONDS.toHours(
+					(xyData.peekLast().x - xyData.peekFirst().x)
+				) >= 2;
+			
+			double timeUnit = (hours ? HOURS : MINUTES).toMillis(1);
+			double[] x = new double[xyData.size()];
+			double[] y = new double[x.length];
+			int i = 0;
+			for(Pair<Long, Integer> p : xyData) {
+				x[i] = ((double)(p.x - x0)) / timeUnit;
+				y[i] = p.y;
+				++i;
+			}
+			
+			XYChart c = QuickChart.getChart(title, (hours ? xLabelHours : xLabelMinutes),
+				yLabel, null, x, y);
+			
+			/* For debugging
 				for(XYSeries s: c.getSeriesMap().values())
 					s.setMarker(SeriesMarkers.CIRCLE);
-				*/
-				
-				byte[] png;
-				try {
-					png = BitmapEncoder.getBitmapBytes(c, BitmapFormat.PNG);
-				} catch (IOException e) {
-					// No idea why this would happen so don't require callers to handle it by
-					// converting to non-declared exception.
-					throw new RuntimeException(e);
-				}
-				
-				return png;
+			 */
+			
+			byte[] png;
+			try {
+				png = BitmapEncoder.getBitmapBytes(c, BitmapFormat.PNG);
+			} catch (IOException e) {
+				// No idea why this would happen so don't require callers to handle it by converting
+				// to non-declared exception.
+				throw new RuntimeException(e);
 			}
-	
+			
+			return png;
+		}
+
 		private final StatisticsPNGRenderer mRenderer;
 	
 		private StatisticsType(StatisticsPNGRenderer r) {

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -321,58 +321,60 @@ public class StatisticsPage extends WebPageImpl {
 	 * their image's URI. FIXME: Add URI getter to StatisticsPNGRenderer. */
 	public static enum StatisticsType implements StatisticsPNGRenderer {
 		TotalDownloadCount(new StatisticsPNGRenderer() {
-	/**
-	 * Renders a chart where the X-axis is the uptime of WoT, and the Y-axis is the total number of
-	 * downloaded {@link IdentityFile}s.
-	 * 
-	 * @see IdentityFileQueueStatistics#mTotalQueuedFiles
-	 * @see IdentityFileQueueStatistics#mTimesOfQueuing */
-	@Override public byte[] getPNG(WebOfTrust wot) {
-		IdentityFileQueueStatistics stats = wot.getIdentityFileQueue().getStatistics();
-		LimitedArrayDeque<Pair<Long, Integer>> timesOfQueuing
-			= stats.mTimesOfQueuing;
-		
-		// Add a dummy entry for the current time to the end of the plot so refreshing the image
-		// periodically shows that it is live even when there is no progress.
-		// Adding it to the obtained statistics is fine as they are a clone() of the original.
-		// Also peekLast() can never return null because mTimesOfQueuing by contract always contains
-		// at least one element.
-		timesOfQueuing.addLast(
-			new Pair<>(CurrentTimeUTC.getInMillis(), timesOfQueuing.peekLast().y));
-		
-		long x0 = stats.mStartupTimeMilliseconds;
-		double[] x = new double[timesOfQueuing.size()];
-		double[] y = new double[x.length];
-		int i = 0;
-		for(Pair<Long, Integer> p : timesOfQueuing) {
-			// FIXME: Switch to hours for large ranges of the plot
-			x[i] = ((double)(p.x - x0)) / (double)MINUTES.toMillis(1);
-			y[i] = p.y;
-			++i;
-		}
-		
-		BaseL10n l = wot.getBaseL10n();
-		String p = "StatisticsPage.PlotBox.TotalDownloadCountPlot.";
-		XYChart c = QuickChart.getChart(l.getString(p + "Title"), l.getString(p + "XAxis.Minutes"),
-			l.getString(p + "YAxis"), null, x, y);
-		
-		/* For debugging
-		for(XYSeries s: c.getSeriesMap().values())
-			s.setMarker(SeriesMarkers.CIRCLE);
-		*/
-		
-		byte[] png;
-		try {
-			png = BitmapEncoder.getBitmapBytes(c, BitmapFormat.PNG);
-		} catch (IOException e) {
-			// No idea why this would happen so don't require callers to handle it by converting
-			// to non-declared exception.
-			throw new RuntimeException(e);
-		}
-		
-		return png;
-	}
-	});
+			/**
+			 * Renders a chart where the X-axis is the uptime of WoT, and the Y-axis is the total
+			 * number of downloaded {@link IdentityFile}s.
+			 * 
+			 * @see IdentityFileQueueStatistics#mTotalQueuedFiles
+			 * @see IdentityFileQueueStatistics#mTimesOfQueuing */
+			@Override public byte[] getPNG(WebOfTrust wot) {
+				IdentityFileQueueStatistics stats = wot.getIdentityFileQueue().getStatistics();
+				LimitedArrayDeque<Pair<Long, Integer>> timesOfQueuing
+					= stats.mTimesOfQueuing;
+				
+				// Add a dummy entry for the current time to the end of the plot so refreshing the
+				// image periodically shows that it is live even when there is no progress.
+				// Adding it to the obtained statistics is fine as they are a clone() of the
+				// original.
+				// Also peekLast() can never return null because mTimesOfQueuing by contract always
+				// contains at least one element.
+				timesOfQueuing.addLast(
+					new Pair<>(CurrentTimeUTC.getInMillis(), timesOfQueuing.peekLast().y));
+				
+				long x0 = stats.mStartupTimeMilliseconds;
+				double[] x = new double[timesOfQueuing.size()];
+				double[] y = new double[x.length];
+				int i = 0;
+				for(Pair<Long, Integer> p : timesOfQueuing) {
+					// FIXME: Switch to hours for large ranges of the plot
+					x[i] = ((double)(p.x - x0)) / (double)MINUTES.toMillis(1);
+					y[i] = p.y;
+					++i;
+				}
+				
+				BaseL10n l = wot.getBaseL10n();
+				String p = "StatisticsPage.PlotBox.TotalDownloadCountPlot.";
+				XYChart c = QuickChart.getChart(l.getString(p + "Title"),
+					l.getString(p + "XAxis.Minutes"),
+					l.getString(p + "YAxis"), null, x, y);
+				
+				/* For debugging
+				for(XYSeries s: c.getSeriesMap().values())
+					s.setMarker(SeriesMarkers.CIRCLE);
+				*/
+				
+				byte[] png;
+				try {
+					png = BitmapEncoder.getBitmapBytes(c, BitmapFormat.PNG);
+				} catch (IOException e) {
+					// No idea why this would happen so don't require callers to handle it by
+					// converting to non-declared exception.
+					throw new RuntimeException(e);
+				}
+				
+				return png;
+			}
+		});
 	
 		private final StatisticsPNGRenderer mRenderer;
 	

--- a/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
+++ b/src/plugins/WebOfTrust/ui/web/StatisticsPage.java
@@ -338,17 +338,13 @@ public class StatisticsPage extends WebPageImpl {
 				Long x0 = stats.mStartupTimeMilliseconds;
 				LimitedArrayDeque<Pair<Long, Integer>> timesOfQueuing
 					= stats.mTimesOfQueuing;
-				
-				BaseL10n l = wot.getBaseL10n();
-				String p = "StatisticsPage.PlotBox.TotalDownloadCountPlot.";
+				String l10n = "StatisticsPage.PlotBox.TotalDownloadCountPlot.";
 
 				// timesOfQueuing is safe to be fed into this:
 				// - getStatistics() returns a clone() so it may be modified.
 				// - IdentityFileQueueStatistics specifies it to always contain at least one entry.
-				// FIXME: Move l.getString() to getTimeBasedPlotPNG()
-				return getTimeBasedPlotPNG(timesOfQueuing, x0,
-					l.getString(p + "Title"), l.getString(p + "XAxis.Hours"), 
-					l.getString(p + "XAxis.Minutes") , l.getString(p + "YAxis"));
+				return getTimeBasedPlotPNG(timesOfQueuing, x0, wot.getBaseL10n(), l10n + "Title", 
+					l10n + "XAxis.Hours",  l10n + "XAxis.Minutes", l10n + "YAxis");
 			}
 		});
 
@@ -364,13 +360,16 @@ public class StatisticsPage extends WebPageImpl {
 		 * @param x0 The {@link CurrentTimeUTC#getInMillis()} of the x=0 origin of the plot. The
 		 *     time labels on the X-axis will not be absolute time but a relative time offset, e.g.
 		 *     "3 minutes". The offset is built against this initial UTC time. 
-		 * @param title The label on top of the plot.
-		 * @param xLabelHours Label of the X-axis if it is automatically chosen to display hours.
-		 * @param xLabelMinutes Label of the X-axis if it automatically chosen to display minutes.
-		 * @param yLabel Label of the Y-axis
+		 * @param l10n The {@link BaseL10n} used to translate the given string keys.
+		 * @param title L10n key of the label on top of the plot.
+		 * @param xLabelHours L10n key of the X-axis label if it is automatically chosen to
+		 *     display hours.
+		 * @param xLabelMinutes L10n key of the X-axis label if it automatically chosen to
+		 *     display minutes.
+		 * @param yLabel L10n key of the Y-axis label.
 		 * @return An image of the PNG format, serialized to a byte array. */
 		public static final byte[] getTimeBasedPlotPNG(
-				LimitedArrayDeque<Pair<Long, Integer>> xyData, long x0,
+				LimitedArrayDeque<Pair<Long, Integer>> xyData, long x0, BaseL10n l10n,
 				String title, String xLabelHours, String xLabelMinutes, String yLabel) {
 			
 			// Add a dummy entry for the current time to the end of the plot so refreshing the image
@@ -397,8 +396,9 @@ public class StatisticsPage extends WebPageImpl {
 				++i;
 			}
 			
-			XYChart c = QuickChart.getChart(title, (hours ? xLabelHours : xLabelMinutes),
-				yLabel, null, x, y);
+			XYChart c = QuickChart.getChart(l10n.getString(title),
+				l10n.getString(hours ? xLabelHours : xLabelMinutes),
+				l10n.getString(yLabel), null, x, y);
 			
 			/* For debugging
 				for(XYSeries s: c.getSeriesMap().values())

--- a/src/plugins/WebOfTrust/ui/web/WebInterface.java
+++ b/src/plugins/WebOfTrust/ui/web/WebInterface.java
@@ -305,14 +305,7 @@ public class WebInterface {
 		}
 
 		public URI getURI(String puzzleID) {
-			final URI baseURI = getURI();
-			
-			try {
-				// The parameter which is baseURI.getPath() may not be null, otherwise the last directory is stripped.
-				return baseURI.resolve(new URI(null, null, baseURI.getPath(), "PuzzleID=" + puzzleID, null));
-			} catch (URISyntaxException e) {
-				throw new RuntimeException(e);
-			}
+			return getURIWithParams("PuzzleID=" + puzzleID);
 		}
 
 		@Override
@@ -449,12 +442,7 @@ public class WebInterface {
 		}
 	
 		public URI getURI(StatisticsType type) {
-			URI u = getURI();
-			try {
-				return u.resolve(new URI(null, null, u.getPath(), "type=" + type, null));
-			} catch (URISyntaxException e) {
-				throw new RuntimeException(e);
-			}
+			return getURIWithParams("type=" + type);
 		}
 	
 		@Override public void handleMethodGET(URI uri, HTTPRequest httpRequest,

--- a/src/plugins/WebOfTrust/ui/web/WebInterface.java
+++ b/src/plugins/WebOfTrust/ui/web/WebInterface.java
@@ -420,6 +420,9 @@ public class WebInterface {
 
 	}
 
+	/** Toadlet which serves the PNG images of all generated statistics PNG images of the enum
+	 *  {@link StatisticsPage.StatisticsType}.
+	 *  New types added to that enum will be served automatically, no changes are required here. */
 	public final class StatisticsPNGWebInterfaceToadlet extends WebInterfaceToadlet {
 		public StatisticsPNGWebInterfaceToadlet(HighLevelSimpleClient highLevelSimpleClient,
 				WebInterface webInterface, NodeClientCore nodeClientCore, String pageTitle) {

--- a/src/plugins/WebOfTrust/ui/web/WebInterface.java
+++ b/src/plugins/WebOfTrust/ui/web/WebInterface.java
@@ -447,9 +447,14 @@ public class WebInterface {
 			
 			super(highLevelSimpleClient, webInterface, nodeClientCore, pageTitle);
 		}
-
+	
 		public URI getURI(StatisticsType type) {
-			return super.getURI().resolve("?" + type.toString());
+			URI u = getURI();
+			try {
+				return u.resolve(new URI(null, null, u.getPath(), "type=" + type, null));
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(e);
+			}
 		}
 	
 		@Override public void handleMethodGET(URI uri, HTTPRequest httpRequest,

--- a/src/plugins/WebOfTrust/ui/web/WebInterfaceToadlet.java
+++ b/src/plugins/WebOfTrust/ui/web/WebInterfaceToadlet.java
@@ -228,4 +228,14 @@ public abstract class WebInterfaceToadlet extends Toadlet implements LinkEnabled
 			throw new RuntimeException(e);
 		}
 	}
+
+	/** Returns {@link #getURI()} plus query string such as "?key1=value1&key2=value2..." */
+	public final URI getURIWithParams(String queryString) {
+		URI u = getURI();
+		try {
+			return u.resolve(new URI(null, null, u.getPath(), queryString, u.getFragment()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
+++ b/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
@@ -54,6 +54,10 @@ public final class LimitedArrayDeque<T> implements Cloneable, Iterable<T> {
 		return mQueue.size();
 	}
 
+	public int sizeLimit() {
+		return mSizeLimit;
+	}
+
 	@Override public LimitedArrayDeque<T> clone() {
 		return new LimitedArrayDeque<>(this);
 	}

--- a/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
+++ b/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
@@ -38,6 +38,14 @@ public final class LimitedArrayDeque<T> implements Cloneable, Iterable<T> {
 		return result;
 	}
 
+	public T peekFirst() {
+		return mQueue.peekFirst();
+	}
+
+	public int size() {
+		return mQueue.size();
+	}
+
 	@Override public LimitedArrayDeque<T> clone() {
 		return new LimitedArrayDeque<>(this);
 	}

--- a/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
+++ b/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
@@ -38,6 +38,10 @@ public final class LimitedArrayDeque<T> implements Cloneable, Iterable<T> {
 		return result;
 	}
 
+	public void clear() {
+		mQueue.clear();
+	}
+
 	public T peekFirst() {
 		return mQueue.peekFirst();
 	}

--- a/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
+++ b/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
@@ -1,0 +1,49 @@
+package plugins.WebOfTrust.util;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+
+/***
+ * A wrapper around class {@link ArrayDeque} which automatically obeys a size limit.
+ * Once the limit is reached adding an element to the tail will remove the head element. */
+public final class LimitedArrayDeque<T> implements Cloneable, Iterable<T> {
+
+	private final ArrayDeque<T> mQueue;
+
+	private final int mSizeLimit;
+
+
+	public LimitedArrayDeque(int sizeLimit) {
+		if(sizeLimit < 1)
+			throw new IllegalArgumentException("sizeLimit is < 1: " + sizeLimit);
+		
+		mQueue = new ArrayDeque<T>();
+		mSizeLimit = sizeLimit;
+	}
+
+	/** Copy-constructor for {@link #clone()}. */
+	private LimitedArrayDeque(LimitedArrayDeque<T> original) {
+		mQueue = original.mQueue.clone();
+		mSizeLimit = original.mSizeLimit;
+	}
+
+	public T addLast(T element) {
+		T result = null;
+		
+		if(mQueue.size() >= mSizeLimit)
+			result = mQueue.removeFirst();
+		
+		mQueue.addLast(element);
+		
+		return result;
+	}
+
+	@Override public LimitedArrayDeque<T> clone() {
+		return new LimitedArrayDeque<>(this);
+	}
+
+	@Override public Iterator<T> iterator() {
+		return mQueue.iterator();
+	}
+
+}

--- a/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
+++ b/src/plugins/WebOfTrust/util/LimitedArrayDeque.java
@@ -46,6 +46,10 @@ public final class LimitedArrayDeque<T> implements Cloneable, Iterable<T> {
 		return mQueue.peekFirst();
 	}
 
+	public T peekLast() {
+		return mQueue.peekLast();
+	}
+
 	public int size() {
 		return mQueue.size();
 	}

--- a/src/plugins/WebOfTrust/util/Pair.java
+++ b/src/plugins/WebOfTrust/util/Pair.java
@@ -1,0 +1,12 @@
+package plugins.WebOfTrust.util;
+
+/** General purpose immutable 2-tuple. */
+public final class Pair<X, Y> {
+	public final X x;
+	public final Y y;
+
+	public Pair(X x, Y y) {
+		this.x = x;
+		this.y = y;
+	}
+}

--- a/src/plugins/WebOfTrust/util/plotting/package-info.java
+++ b/src/plugins/WebOfTrust/util/plotting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes to preprocess data to make it suitable for plotting, and to plot it using the
+ * XChart library, e.g. as {@link org.knowm.xchart.XYChart}. */
+package plugins.WebOfTrust.util.plotting;


### PR DESCRIPTION
_Please merge this into branch `issue-0007021-plot-download-stats` with `--ff-only`._
_This also contains the commits of the previous PRs to that branch. Merge those first to only see the relevant diff here._

---

**Notice:** You don't need to review this for mathematical correctness, some errors will be corrected in upcoming commits and all plot computation functions will receive unit tests.