### PR TITLE
Eclipse: Use Gradle instead of Ant, part 2

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="db4o-7.4/db4o.jar"/>
+	<classpathentry kind="src" output="bin/main" path="src">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/test" path="test">
+		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fred"/>
-	<classpathentry kind="lib" path="/fred/lib/freenet/freenet-ext.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/junit4.jar"/>
-	<classpathentry kind="output" path="build"/>
+	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/.externalToolBuilders/WoT Ant.launch
+++ b/.externalToolBuilders/WoT Ant.launch
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
-<stringAttribute key="org.eclipse.ant.ui.ATTR_ANT_CLEAN_TARGETS" value="clean,"/>
-<booleanAttribute key="org.eclipse.ant.ui.ATTR_TARGETS_UPDATED" value="true"/>
-<booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="false"/>
-<stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${project}"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/WebOfTrust"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
-<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
-<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="WebOfTrust"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/WebOfTrust/build.xml}"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,clean"/>
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/WebOfTrust}"/>
+    <stringAttribute key="org.eclipse.ant.ui.ATTR_ANT_CLEAN_TARGETS" value="clean,"/>
+    <booleanAttribute key="org.eclipse.ant.ui.ATTR_TARGETS_UPDATED" value="true"/>
+    <booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${project}"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/WebOfTrust"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="WebOfTrust"/>
+    <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/WebOfTrust/build.xml}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,clean"/>
+    <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/WebOfTrust}"/>
 </launchConfiguration>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 build
 build-test
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 build-test
 dist
 override.properties
+/.gradle/

--- a/.project
+++ b/.project
@@ -11,6 +11,11 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
 			<arguments>
 				<dictionary>
@@ -22,5 +27,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,8 @@
+auto.sync=true
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(4.10.3))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+offline.mode=true
+override.workspace.settings=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ dist: trusty
 sudo: false
 
 env:
-  - FREENET_MINIMUM_JAVA_VERSION=7
+  global:
+    # NOTICE: A hardcoded copy of this value exists at "matrix:", when updating also change that!
+    - FREENET_MINIMUM_JAVA_VERSION=7
 
 addons:
   apt:
@@ -42,7 +44,7 @@ install:
   - |
     if [ ! -e fred/.git ] ; then # Must check subdir, main one will be created by Travis cache config.
       FRED_UPDATED=1
-      git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred
+      git clone https://github.com/freenet/fred.git --branch "$FRED" --single-branch --depth 1 fred
     fi
   - cd fred
   - git reset --hard # Undo our manual changes to ./gradlew to prevent merge conflicts
@@ -71,7 +73,7 @@ before_script: |
   else
     echo "No changes at fred, not recompiling."
   fi
-  if [ "$TRAVIS_JDK_VERSION" = "openjdk$FREENET_MINIMUM_JAVA_VERSION" ] ; then
+  if [ "$DEPLOY" = 1 ] ; then
     echo "Starting a Freenet node already to establish connectivity far before deploy stage..."
     "$TRAVIS_BUILD_DIR"/.travis.start-freenet.sh
   fi
@@ -83,36 +85,53 @@ script:
   # Don't allow Travis to override the low memory limit which our builder sets with a higher one.
   - unset _JAVA_OPTIONS
   - echo 'fred version:' ; java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
-  # Use Gradle instead of Ant as it supports using multiple CPU cores on the unit tests.
   # Use the same Gradle as fred to re-use the fixes we applied to it above and because Travis'
   # Gradle version is too old for Java >= 9.
   - ln -sf "$TRAVIS_BUILD_DIR/../fred/gradlew"
-  # ... but still use Ant on one Java version to ensure it keeps working.
-  # And don't use it on the minimum Java version as there we will run the deployment - which takes
-  # long enough already, and Ant is slower than Gradle, so we would risk exhausting the time limit.
   - |
-    if [ "$TRAVIS_JDK_VERSION" = "openjdk$((FREENET_MINIMUM_JAVA_VERSION + 1))" ] ; then
+    if [ "$BUILDER" = "ant" ] ; then
         ant clean && ant
-    else
+    elif [ "$BUILDER" = "gradle" ] ; then
         ./gradlew clean test jar
-    fi
+    else false ; fi
   # To test the Ant and Gradle builders against each other uncomment the following.
   ## - tools/compare-gradle-jars-with-ant-jars
   ## - tools/compare-gradle-tests-with-ant-tests
 
-jdk:
-  - openjdk7
-  - openjdk8
-  - openjdk9
-  - openjdk10
-  - openjdk11
-  - openjdk12
-  # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
-  - oraclejdk8
-  # oraclejdk9: No more updates by Oracle: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
-  # oraclejdk10: Not supported anymore: https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612
-  - oraclejdk11
-  # oraclejdk12: Not available on Travis CI as of 2019-05-04, was released 2019-03.
+
+# Use Gradle instead of Ant as it supports using multiple CPU cores on the unit tests.
+env: FRED=next BUILDER=gradle
+matrix:
+  include:
+    # We will run most of our tests against fred branch next (= the development branch) to fulfill
+    # our purpose of integration testing.
+    # But first we will hereby also test on branch master to ensure WoT works against the latest
+    # stable release as well because plugins can be updated without a new Freenet release.
+    # We only test against master on a single Java version to keep the matrix small, all the others
+    # will be tested against next by the second and following "jdk:" below.
+    # We will also deploy from this Java version and fred version because they are the minimum
+    # so the resulting JAR and fred upload will work everywhere.
+    - env: FRED=master BUILDER=gradle DEPLOY=1
+      # Travis doesn't support this yet so we will hardcode it:
+      ## jdk: openjdk$FREENET_MINIMUM_JAVA_VERSION
+      jdk: openjdk7
+
+    - jdk: openjdk7
+      # Still use Ant on one Java version to ensure it keeps working.
+      # Don't use it on the above job because deployment happens there which is slow, just like Ant
+      # - we would risk exhausting the time limit.
+      env: FRED=next BUILDER=ant
+    - jdk: openjdk8
+    - jdk: openjdk9
+    - jdk: openjdk10
+    - jdk: openjdk11
+    - jdk: openjdk12
+    # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+    - jdk: oraclejdk8
+    # oraclejdk9: No more updates by Oracle: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
+    # oraclejdk10: Not supported anymore: https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612
+    - jdk: oraclejdk11
+    # oraclejdk12: Not available on Travis CI as of 2019-05-04, was released 2019-03.
 
 deploy:
   provider: script
@@ -121,4 +140,4 @@ deploy:
   script: ./.travis.upload-jar-to-freenet.sh
   on:
     all_branches: true
-    condition: $TRAVIS_JDK_VERSION = "openjdk$FREENET_MINIMUM_JAVA_VERSION"
+    condition: $DEPLOY = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,12 +108,14 @@ jdk:
   - openjdk8
   - openjdk9
   - openjdk10
-  - oraclejdk8
-  - oraclejdk9
-  # oraclejdk11: As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
-  # openjdk11:   As of 2018-09-26 fred's Gradle fails with: "Could not determine java version from '11'."
-  # oraclejdk10: Not supported anymore: https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612
+  - openjdk11
+  - openjdk12
   # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+  - oraclejdk8
+  # oraclejdk9: No more updates by Oracle: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
+  # oraclejdk10: Not supported anymore: https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612
+  - oraclejdk11
+  # oraclejdk12: Not available on Travis CI as of 2019-05-04, was released 2019-03.
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,6 @@ before_script: |
       rm ./gradlew &&
       ln -s "$(which gradle)" ./gradlew
     fi &&
-    if [[ "$TRAVIS_JDK_VERSION" = "openjdk9" || "$TRAVIS_JDK_VERSION" = "openjdk10" ]] ; then
-      # Workaround for Gradle failing on openjdk9 and above with:
-      #   sun.security.validator.ValidatorException: PKIX path building failed: [...]
-      # TODO: Code quality: Added 2018-09-26, remove after some time and see if it works without this.
-      USE_SYSTEM_CERTS=1 &&
-      mv "${JAVA_HOME}/lib/security/cacerts" "${JAVA_HOME}/lib/security/cacerts.jdk" &&
-      ln -s '/etc/ssl/certs/java/cacerts' "${JAVA_HOME}/lib/security/cacerts"
-    fi &&
     # TODO: freenet.jar won't contain class Version if we don't run the
     # clean task in a separate execution of Gradle. I.e. this wouldn't work:
     #   $ gradle clean jar
@@ -75,10 +67,6 @@ before_script: |
     # "copyRuntimeLibs" copies the JAR *and* dependencies - which WoT also
     # needs - to build/output/
     ./gradlew jar copyRuntimeLibs -x test &&
-    if [ "$USE_SYSTEM_CERTS" = 1 ] ; then
-        rm "${JAVA_HOME}/lib/security/cacerts" &&
-        mv "${JAVA_HOME}/lib/security/cacerts.jdk" "${JAVA_HOME}/lib/security/cacerts"
-    fi &&
     cd "$TRAVIS_BUILD_DIR"
   else
     echo "No changes at fred, not recompiling."
@@ -99,7 +87,15 @@ script:
   # Use the same Gradle as fred to re-use the fixes we applied to it above and because Travis'
   # Gradle version is too old for Java >= 9.
   - ln -sf "$TRAVIS_BUILD_DIR/../fred/gradlew"
-  - ./gradlew clean test jar
+  # ... but still use Ant on one Java version to ensure it keeps working.
+  # And don't use it on the minimum Java version as there we will run the deployment - which takes
+  # long enough already, and Ant is slower than Gradle, so we would risk exhausting the time limit.
+  - |
+    if [ "$TRAVIS_JDK_VERSION" = "openjdk$((FREENET_MINIMUM_JAVA_VERSION + 1))" ] ; then
+        ant clean && ant
+    else
+        ./gradlew clean test jar
+    fi
   # To test the Ant and Gradle builders against each other uncomment the following.
   ## - tools/compare-gradle-jars-with-ant-jars
   ## - tools/compare-gradle-tests-with-ant-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
       git clone https://github.com/freenet/fred.git --branch next --single-branch --depth 1 fred
     fi
   - cd fred
+  - git reset --hard # Undo our manual changes to ./gradlew to prevent merge conflicts
   - git fetch && if [ "$(git rev-parse @)" != "$(git rev-parse @{u})" ] ; then FRED_UPDATED=1 ; git pull ; fi
   - cd "$TRAVIS_BUILD_DIR"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ script:
   - echo 'Checksums of dependencies:' ; sha256sum ../fred/build/output/*
   # Don't allow Travis to override the low memory limit which our builder sets with a higher one.
   - unset _JAVA_OPTIONS
+  - echo 'fred version:' ; java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
   # Use Gradle instead of Ant as it supports using multiple CPU cores on the unit tests.
   # Use the same Gradle as fred to re-use the fixes we applied to it above and because Travis'
   # Gradle version is too old for Java >= 9.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+### Copyright
+
+WoT copyright is held by Freenet Project Incorporated.  WoT is
+distributed under the GPL license. You can find it in the file called
+"gpl.txt".
+
+---
+
+### Legalese
+
+WoT
+Copyright (C) 2008-2019 Freenet Project Incorporated
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -18,65 +18,62 @@ These constitute a democratic vote among users, the result decides if a particul
 considered as legitimate or as a spammer. The content of spammers is completely ignored then, it
 won't cause any network traffic.
 
-### Compilation
+While WoT does have a user interface of its own which can be used to manage identites and trusts,
+it is intended to be used as a general-purpose library to allow actual Freenet applications to
+be built upon it. As of 2019 these are:
+- [Sone](https://github.com/Bombe/Sone) - social networking
+- [FlogHelper](https://github.com/freenet/plugin-FlogHelper) - blogging
+- [Freemail](https://github.com/freenet/plugin-Freemail) - email
+- [Freetalk](https://github.com/freenet/plugin-Freetalk) - forum systems
 
-In order to compile WOT, you need to obtain the source code of Freenet ("fred") and WOT:
-https://github.com/freenet/fred-staging
-https://github.com/freenet/plugin-WoT-staging
+### Compiling
 
-The "staging" repositories are the latest development versions. Replace staging with "official" to get only
-the latest official release versions.
+#### Dependencies
 
-We recommend using Eclipse: The repositories ship with an Eclipse project configuration.
-To use Eclipse:
-- Add the EGit plugin to Eclipse so you don't have to use command-line Git. Newer Eclipse versions 
-  (4.2 aka Kepler at least) ship with it by default.
-- When having EGit installed, use "File" / "Import" in Eclipse to import the Git projects.
-- Rename the "fred-staging" project in Eclipse to "fred" and the "plugin-WoT-staging"
-  project to "WebOfTrust". Renaming can be done by right-clicking a project, selecting "Refactor", then "Rename".
-- Create a file called "override.properties" in the fred project. Write 'lib.contrib.get = true' into it.
-  This will make the builder download the latest official freenet-ext.jar so you don't have to compile it yourself.
-- Download the Bouncycastle crypto library from www.bouncycastle.org and store it as "fred/lib/bcprov.jar"
-  If you have a working Freenet installation, you can also just copy it from your Freenet directory.
-  It might be called something similar to "bcprov-jdk15on-149.jar".
+Clone the [fred](https://github.com/freenet/fred) and plugin-WebOfTrust repositories into the same
+parent directory.  
+Compile fred using its instructions.
 
-Now building should work using Eclipse's "Project" menu. 
-We recommend disabling "Build automatically" in the menu because compiling Fred and WOT can take 
-a long time and therefore it's better to do it manually only when you need it.
+#### Compiling by command line
 
-If you don't want to use Eclipse but instead want to compile manually from the shell, it can be done like this:
 ```bash
-  $ git clone https://github.com/freenet/fred-staging.git fred
-  $ cd fred
-  $ echo 'lib.contrib.get = true' >> override.properties
-  # Download the Bouncycastle crypto library from www.bouncycastle.org and put it in lib/bcprov.jar
-  # If you have a working Freenet installation, you can also just copy it from your Freenet directory.
-  # It might be called something similar to "bcprov-jdk15on-149.jar".
-  $ ant
-  $ cd ..
-  $ git clone https://github.com/freenet/plugin-WoT-staging.git WebOfTrust
-  $ cd WebOfTrust
-  $ ant
+ant clean
+ant
+# If you get errors about missing classes check build.xml for whether the JAR locations are correct.
 ```
 
-### Running
+The output `WebOfTrust.jar` will be in the `dist` directory.  
+You can load it on the `Plugins` page of the Freenet web interface.  
 
-Visit the plugins page ("http://127.0.0.1:8888/plugins/ by default) with your Web browser.
+#### Compiling with Eclipse
 
-In the Load Plugin box, enter: /your-eclipse-workspace-path/WebOfTrust/dist/WebOfTrust.jar and click the Load button.
+* Import the project configurations which fred and WoT ship in Eclipse.  
+  **NOTICE:** As of 2018-07 fred currently does not ship one, you can use an old release for now.
+  The newest which still includes the project can be obtained with:  
+  	`git checkout build01480`  
+  Be aware that its build instructions will be different compared to newer releases, so check the
+  `README.md` after the above command.
+* Since build01480 does not automatically download its dependencies, get them from an existing
+  Freenet installation:
+  * Put `freenet-ext.jar` in `fred/lib/freenet`
+  * Put `bcprov.jar` (from e.g. `bcprov-jdk15on-149.jar`, name may vary) in `fred/lib`.
+* If necessary fix the build paths for your Eclipse projects so they refer to the correct JAR paths.
+* Disable automatic building in Eclipse's `Project` menu as the Ant builders take quite a bit of time to execute.
 
-After the plugin is loaded, WOT will be accessible at the "Community" menu of your Freenet web interface.
+Now building should work using the `Project` menu or toolbar buttons.
 
-### Understanding
+### Debugging
 
-See https://wiki.freenetproject.org/Web_of_Trust
-
+Run fred's class `freenet.node.NodeStarter` using the Eclipse debugger.  
+Browse to Freenet's [Plugins page](http://127.0.0.1:8888/plugins/).  
+Use the `Load Plugin` box to load `PARENT_DIRECTORY/WebOfTrust/dist/WebOfTrust.jar`.  
+After the plugin is loaded, WoT will be accessible at the `Community` menu.  
+Read [the debugging instructions](developer-documentation/Debugging.txt) for further details.
 
 ### Development
 
-See the files in the "developer-documentation" folder.
-
-Also, see the following pages in the Freenet wiki:
-https://wiki.freenetproject.org/Web_of_Trust
-https://wiki.freenetproject.org/Web_Of_Trust_development
-https://wiki.freenetproject.org/Plugin_development_tutorial
+See:
+- the files in the [developer-documentation](developer-documentation) directory.
+- https://github.com/freenet/wiki/wiki/Web-of-Trust
+- https://github.com/freenet/wiki/wiki/Web-Of-Trust-Development
+- https://github.com/freenet/wiki/wiki/Plugin-Development-Tutorial

--- a/README.md
+++ b/README.md
@@ -79,20 +79,52 @@ tools/benchmark-unit-test TEST_CLASS TEST_FUNCTION NUMBER_OF_ITERATIONS
 
 #### Compiling with Eclipse
 
-* Import the project configurations which fred and WoT ship in Eclipse.  
-  **NOTICE:** As of 2018-07 fred currently does not ship one, you can use an old release for now.
-  The newest which still includes the project can be obtained with:  
-  	`git checkout build01480`  
-  Be aware that its build instructions will be different compared to newer releases, so check the
-  `README.md` after the above command.
-* Since build01480 does not automatically download its dependencies, get them from an existing
-  Freenet installation:
-  * Put `freenet-ext.jar` in `fred/lib/freenet`
-  * Put `bcprov.jar` (from e.g. `bcprov-jdk15on-149.jar`, name may vary) in `fred/lib`.
-* If necessary fix the build paths for your Eclipse projects so they refer to the correct JAR paths.
-* Disable automatic building in Eclipse's `Project` menu as the Ant builders take quite a bit of time to execute.
+These instructions have been written for the Eclipse package `Eclipse IDE for Java Developers` of
+version `2018-12` for `Linux 64-bit`, which you can get
+[here](https://www.eclipse.org/downloads/packages/release/2018-12/r).
 
-Now building should work using the `Project` menu or toolbar buttons.
+1. Import the fred project into Eclipse: `File / Import... / Gradle / Existing Gradle Project`.
+2. Configure the project to use Gradle version `4.10.3` at
+   `Right click the project / Properties / Gradle`.  
+   Enable `Automatic project Synchronization` there as well.
+3. Enable Eclipse's `Gradle executions` and `Gradle tasks` views at `Window / Show view / Other...`.
+4. In the `Gradle Tasks` view, right click `fred` and select `Run Default Gradle Tasks`.  
+   Wait for Gradle to finish. You can see its output and error messages in the `Console` view.
+5. Once the above step is finished, the green `Run` button in the main toolbar will show a run
+   configuration for fred in its dropdown menu.  
+   Open the UI to edit it at `Run / Run Configurations...` and there set:  
+   * `Gradle Tasks / Gradle tasks: jar copyRuntimeLibs`  
+      The latter ensures Gradle copies all dependency JARs of Freenet to a single directory which
+      WoT will use.  
+     **TODO**: Prefix with `clean` task once it doesn't break `Version.class` anymore.
+   * `Arguments / Program Arguments: -x test` optionally to skip running the fred unit tests at
+      every build.
+6. Re-run fred's Gradle with the above run configuration via `Run / <configuration name>`.
+7. Import the WoT project as type `General / Existing Projects into Workspace` - that type is what
+   to use here because the WoT repository already contains an Eclipse project configuration.
+8. Ensure a Gradle run configuration for WoT is created by running the default tasks like you did
+   for fred.  
+   Set its Gradle tasks to `jar`, or `clean jar` if you want to ensure the JAR is always fully
+   rebuilt. Not fully rebuilding may cause e.g. deleted classes to persist in the JAR, though
+   I have not tested if this still applies to a build system as modern as Gradle.
+
+**Notice**: Building using `Project / Build project` or `Project / Build Automatically` or the
+toolbar buttons does not seem to trigger Gradle with the said Eclipse version!  
+It seems that this only triggers Eclipse's internal Java builder which is used to empower Eclipse's
+own features.  
+As a consequence, manually run Gradle using the aforementioned `Run` button in case you need the
+WoT JAR as output, e.g. for the following `Debugging` section.  
+Running the unit tests is also done by that, or by Eclipse's own UI for running tests. The Eclipse
+UI however does not exclude certain slow tests which WoT's Gradle would only run optionally.  
+Ideally you would use Gradle to run all tests, and the Eclipse UI to selectively repeat only single
+failing ones in order to debug them with the Eclipse debugger.
+
+**Notice**: Should Eclipse show errors about missing JARs such as `db4o.jar` and say they prevent it
+from building: Notice that the JARs likely have in fact been created by the fred/WoT Gradle
+builders on the filesystem already, so you can fix Eclipse to notice them by:
+1. `Right click the project / Gradle / Refresh Gradle Project`.
+2. `Project / Build Project` to manually start a build. Automatic building might have to be disabled
+   in the same menu.
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,24 @@
-COPYRIGHT
-=========
+## Web of Trust - a collaborative spam filter for Freenet
 
-WOT copyright is held by Freenet Project Incorporated.  WOT is
-distributed under the GPL license. You can find it in the file called
-"gpl.txt".
-----------------
+The [Freenet](https://freenetproject.org) plugin Web of Trust (WoT) tries to solve the problem of
+spam being an important threat to address in an anonymous, censorship-resistant network:  
+Where an attacker cannot take down content they will attempt to get rid of it by drowning it in
+spam.
 
-WOT
-Copyright (C) 2008-2014 Freenet Project Incorporated
+Conventional spam filters cannot work in such an environment:
+- An attacker is anonymous like everyone else so they cannot be blocked by e.g. an IP address.
+- Because Freenet is a peer-to-peer network its available bandwidth is scarce and thus spam must
+  not even be downloaded before filtering it out to avoid
+  [denial of service](https://en.wikipedia.org/wiki/Denial-of-service_attack) - filtering spam by
+  e.g. lists of bad words won't work.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
+WoT deals with these issues by allowing each user to create so-called _identities_ which can assign
+_trust values_ to the identities of other users.  
+These constitute a democratic vote among users, the result decides if a particular identity is
+considered as legitimate or as a spammer. The content of spammers is completely ignored then, it
+won't cause any network traffic.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-COMPILATION
-===========
+### Compilation
 
 In order to compile WOT, you need to obtain the source code of Freenet ("fred") and WOT:
 https://github.com/freenet/fred-staging
@@ -35,21 +30,22 @@ the latest official release versions.
 We recommend using Eclipse: The repositories ship with an Eclipse project configuration.
 To use Eclipse:
 - Add the EGit plugin to Eclipse so you don't have to use command-line Git. Newer Eclipse versions 
-(4.2 aka Kepler at least) ship with it by default.
--  When having EGit installed, use "File" / "Import" in Eclipse to import the Git projects.
+  (4.2 aka Kepler at least) ship with it by default.
+- When having EGit installed, use "File" / "Import" in Eclipse to import the Git projects.
 - Rename the "fred-staging" project in Eclipse to "fred" and the "plugin-WoT-staging"
-project to "WebOfTrust". Renaming can be done by right-clicking a project, selecting "Refactor", then "Rename".
+  project to "WebOfTrust". Renaming can be done by right-clicking a project, selecting "Refactor", then "Rename".
 - Create a file called "override.properties" in the fred project. Write 'lib.contrib.get = true' into it.
-This will make the builder download the latest official freenet-ext.jar so you don't have to compile it yourself.
+  This will make the builder download the latest official freenet-ext.jar so you don't have to compile it yourself.
 - Download the Bouncycastle crypto library from www.bouncycastle.org and store it as "fred/lib/bcprov.jar"
-If you have a working Freenet installation, you can also just copy it from your Freenet directory.
-It might be called something similar to "bcprov-jdk15on-149.jar".
+  If you have a working Freenet installation, you can also just copy it from your Freenet directory.
+  It might be called something similar to "bcprov-jdk15on-149.jar".
 
 Now building should work using Eclipse's "Project" menu. 
 We recommend disabling "Build automatically" in the menu because compiling Fred and WOT can take 
 a long time and therefore it's better to do it manually only when you need it.
 
 If you don't want to use Eclipse but instead want to compile manually from the shell, it can be done like this:
+```bash
   $ git clone https://github.com/freenet/fred-staging.git fred
   $ cd fred
   $ echo 'lib.contrib.get = true' >> override.properties
@@ -61,10 +57,9 @@ If you don't want to use Eclipse but instead want to compile manually from the s
   $ git clone https://github.com/freenet/plugin-WoT-staging.git WebOfTrust
   $ cd WebOfTrust
   $ ant
+```
 
-
-RUNNING
-=======
+### Running
 
 Visit the plugins page ("http://127.0.0.1:8888/plugins/ by default) with your Web browser.
 
@@ -72,14 +67,12 @@ In the Load Plugin box, enter: /your-eclipse-workspace-path/WebOfTrust/dist/WebO
 
 After the plugin is loaded, WOT will be accessible at the "Community" menu of your Freenet web interface.
 
-UNDERSTANDING
-=============
+### Understanding
 
 See https://wiki.freenetproject.org/Web_of_Trust
 
 
-DEVELOPMENT
-===========
+### Development
 
 See the files in the "developer-documentation" folder.
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ defaultTasks 'jar', 'test'
 sourceSets.main.java.srcDirs = ['src/']
 sourceSets.test.java.srcDirs = ['test/']
 sourceCompatibility = targetCompatibility = 7
+tasks.withType(JavaCompile) { options.encoding = "UTF-8" }
 javadoc.enabled = false
 
 configurations { junit } // Needed when we manually specify the tests' classpath

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-// FIXME: Mention this script in README. Say that it is experimental.
-// TODO: Code quality: Use Gradle's dependency management + gradle-witness instead of flat files
-// Postponing this until I know how to import fred's dependency list to avoid duplicating it.
-
 apply plugin: 'java'
 defaultTasks 'jar', 'test'
 sourceSets.main.java.srcDirs = ['src/']
@@ -12,6 +8,9 @@ javadoc.enabled = false
 configurations { junit } // Needed when we manually specify the tests' classpath
 dependencies {
 	// Run fred's Gradle with "./gradlew jar copyRuntimeLibs" to produce this directory
+	// TODO: mvn.freenetproject.org is not browseable so I don't know the proper URI for fred and
+	// its dependencies and hence am including the dependencies as flat files.
+	// Use Gradle's dependency management + gradle-witness once this has been resolved.
 	compile fileTree(dir: '../fred/build/output/', include: '*.jar')
 	compile files('db4o-7.4/db4o.jar')
 	junit files('/usr/share/java/junit4.jar', '/usr/share/java/hamcrest-core.jar')
@@ -19,7 +18,8 @@ dependencies {
 }
 
 task compileDb4o(type: Exec) {
-	outputs.upToDateWhen { file('db4o-7.4/db4o.jar').exists() } // FIXME: Replace w/ incremental Ant
+	// See https://bugs.freenetproject.org/view.php?id=7058
+	outputs.upToDateWhen { file('db4o-7.4/db4o.jar').exists() }
 	workingDir 'db4o-7.4'
 	commandLine 'ant', "-Djavac.source.version=" + sourceCompatibility,
 	                   "-Djavac.target.version=" + targetCompatibility
@@ -79,7 +79,10 @@ test {
 		exclude '**/TickerDelayedBackgroundJobTest.class'
 	}
 	
-	// failFast = true // TODO: Performance: As of 2018-10-03 doesn't work on Travis CI yet
+	/* TODO: Performance: As of 2019-04-28 doesn't work on Travis CI yet because the Gradle version
+	/* on Ubuntu Trusty is too old - and we cannot use Ubuntu Xenial because Java 7 doesn't work
+	/* there but it is still the minimal Java version required by Freenet. */
+	// failFast = true
 	maxHeapSize = "512m"
 	maxParallelForks = Runtime.runtime.availableProcessors()
 	forkEvery = 1 // One VM per test, for safety and probably needed for maxParallelForks to work

--- a/build.xml
+++ b/build.xml
@@ -97,7 +97,7 @@
 
 	<presetdef name="javac">
 		<!--
-		Workaround for ant 1.8 misfeature. TODO: Remove when ant fixes this.
+		includeantruntime is a workaround for an ant 1.8 misfeature. TODO: Remove when ant fixes this.
 		
 		If we don't set this to false, we will get "warning: 'includeantruntime' was not set, defaulting to
 		build.sysclasspath=last; set to false for repeatable builds"
@@ -107,7 +107,7 @@
 		is not sensitive to the environment in which it is run."
 		Source: https://ant.apache.org/manual/Tasks/javac.html)
 		-->
-		<javac includeantruntime="false" />
+		<javac includeantruntime="false" encoding="UTF-8"/>
 	</presetdef>
 
 	<exec executable="git"
@@ -149,7 +149,6 @@
 			useNativeBasedir="true"/>
 	</target>
 
-
 	<target name="print-libs">
 		<echo>External dependencies on classpath follow, but ONLY those which did exist.</echo>
 		<echo>(This cannot tell which JARs are missing because that would require ant-contrib</echo>
@@ -168,7 +167,7 @@
 	<target name="mkdir">
 		<mkdir dir="${build}"/>
 		<mkdir dir="${build-test}"/>
-		<mkdir dir="${build-test}/test"/>
+		<mkdir dir="${build-test}/classes"/>
 		<mkdir dir="${build-test-coverage}"/>
 		<mkdir dir="${dist}"/>
 	</target>
@@ -195,7 +194,7 @@
 			<include name="${version.src}"/>
 		</javac>
 
-		<javac srcdir="src/" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}" encoding="UTF-8">
+		<javac srcdir="src/" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}">
 			<classpath>
 				<path refid="submodules.path"/>
 				<path refid="lib.path"/>
@@ -220,8 +219,8 @@
 	</condition>
 
 	<target name="junit-compile" depends="compile" if="unit.dependencies">
-		<javac srcdir="test/" destdir="${build-test}/test" debug="on" optimize="on"
-				source="${source-version}" target="${target-version}" >
+		<javac srcdir="test/" destdir="${build-test}/classes" debug="on" optimize="on"
+				source="${source-version}" target="${target-version}">
 			
 			<classpath>
 				<path refid="submodules.path"/>
@@ -235,7 +234,7 @@
 		</javac>
 		
 		<!-- Copy main non-test classes to tests so we can produce a full working WoT JAR -->
-		<copy todir="${build-test}/test" overwrite="false">
+		<copy todir="${build-test}/classes" overwrite="false">
 			<fileset dir="${build}/"/>
 		</copy>
 	</target>
@@ -248,7 +247,12 @@
 		<taskdef classpathref="cobertura.path" resource="tasks.properties"/>
 		
 		<cobertura-instrument datafile="${build-test-coverage}/cobertura.ser">
-			<fileset dir="${build-test}/test">
+			<auxClasspath>
+				<path refid="submodules.path"/>
+				<path refid="lib.path"/>
+			</auxClasspath>
+			
+			<fileset dir="${build-test}/classes">
 				<include name="**/*.class" />
 				<!-- kaptcha is a third-party library -->
 				<exclude name="plugins/WebOfTrust/introduction/captcha/kaptcha/**/*"/>
@@ -267,7 +271,7 @@
 				<include name="*.txt"/> <!-- Include the GPL -->
 			</fileset>
 			
-			<fileset dir="${build-test}/test/"/> <!-- Separate directory to exclude the JAR -->
+			<fileset dir="${build-test}/classes/"/> <!-- Separate directory to exclude the JAR -->
 			<zipfileset>
 				<path refid="submodules.path"/>
 			</zipfileset>
@@ -275,16 +279,17 @@
 	</target>
 
 	<target name="junit" depends="junit-package" unless="${test.skip}"
-			description="Runs all unit tests. Options:&#10;
+			description="Runs all unit tests. Options to specify with 'ant -D':&#10;
 		        - Set test.coverage=true to analyze test coverage. View by e.g.: firefox test-coverage/html/index.html&#10;
-		        - Set test.skip=true to skip&#10;
-		        - Set test.class=&lt;test class&gt; (e.g. test.class=plugins.WebOfTrust.WoTTest) to run a single test)&#10;
+		        - Set test.skip=true to skip. The tests will still be compiled so you can run them from e.g. Eclipse!&#10;
+		        - Set test.class=&lt;test class&gt; (e.g. test.class=plugins.WebOfTrust.WoTTest) to run a single test&#10;
 		        - Set test.benchmark=true to run benchmarks.&#10;
 		        - Set test.unreliable=true to run tests which may fail on slow machines.">
 		
 		<fail unless="${unit.dependencies}" message="One of the unit test dependencies not found:&#10;
 			${junit.location}&#10;
 			${hamcrest.location}&#10;
+			You can adjust these paths in file 'override.properties', see 'build.xml'.&#10;
 			Use parameter -Dtest.skip=true to compile without running the self-tests.&#10;
 			WARNING: Web of Trust uses lots of comprehensive tests, changing the code without&#10;
 			running them is a very bad idea!"/>
@@ -306,16 +311,11 @@
 				<pathelement location="${hamcrest.location}"/>
 				<pathelement location="${cobertura.location}" if:true="${test.coverage}"/>
 			</classpath>
-
-			<!-- Workaround for Cobertura failing on Java 7 with:
-				   "Expecting a stackmap frame at branch target [...]"
-			     TODO: Remove if not necessary anymore. Added on 2016-05-31. -->
-			<jvmarg if:true="${test.coverage}" value="-XX:-UseSplitVerifier"/>
 			
 			<assertions><enable/></assertions>
 			<formatter type="plain" usefile="false"/>
 			<test if="test.class" name="${test.class}"/>
-			<batchtest unless="test.class" fork="yes">
+			<batchtest unless="test.class">
 				<zipfileset src="${build-test-jar}">
 					<include name="**/*Test*.class"/>
 					<!-- Exclude member classes:
@@ -361,7 +361,7 @@
 			<assertions><disable/></assertions>
 			<formatter type="plain" usefile="false"/>
 			<test if="test.class" name="${test.class}"/>
-			<batchtest unless="test.class" fork="yes">
+			<batchtest unless="test.class">
 				<zipfileset src="${build-test-jar}">
 					<include name="**/*Benchmark*.class"/>
 					<!-- Exclude member classes:

--- a/build.xml
+++ b/build.xml
@@ -195,7 +195,6 @@
 			<include name="${version.src}"/>
 		</javac>
 
-		<!-- FIXME: remove the debug and replace with optimize -->
 		<javac srcdir="src/" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}" encoding="UTF-8">
 			<classpath>
 				<path refid="submodules.path"/>

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -243,7 +243,8 @@ CHANGELOG about stuff only interesting for developers
     compiling.
   - benchmark-unit-tests-from-travis: to process a log file from
     Travis CI to produce the same output as the above local benchmark
-    script.
+    script. To use this change .travis.yml to use the Ant builder
+    instead of Gradle as Gradle does not measure test runtime.
 
   They produce sorted output like this:
     1.234 sec package.ClassName1.testFunction1()

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -243,8 +243,9 @@ CHANGELOG about stuff only interesting for developers
     compiling.
   - benchmark-unit-tests-from-travis: to process a log file from
     Travis CI to produce the same output as the above local benchmark
-    script. To use this change .travis.yml to use the Ant builder
-    instead of Gradle as Gradle does not measure test runtime.
+    script. Be aware that only log files of the openjdk8 job on Travis
+    will work: The others use Gradle instead of Ant, and Gradle does not
+    measure test runtime.
 
   They produce sorted output like this:
     1.234 sec package.ClassName1.testFunction1()
@@ -299,7 +300,7 @@ CHANGELOG about stuff only interesting for developers
   in parallel on all available CPU cores to greatly reduce their
   runtime.
   To reap immediate benefit of this, Travis CI has been changed to use
-  Gradle instead of Ant.
+  Gradle instead of Ant (except on one Java version to keep Ant tested).
   That may speed up the builds by up to 50% as Travis provides 2 CPU
   cores.
   It will ensure builds exceed the 50 minute timeout less frequently

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -412,6 +412,8 @@ CHANGELOG about stuff only interesting for developers
 
 - 0007033: [Code quality] Speed up Travis CI builds: Don't recompile
            fred if "git pull" changed nothing (xor)
+  0007068: [Code quality] Travis CI: Print the Version.java info of the
+           fred we compiled (xor)
 
   The Travis CI build script of WoT usually obtains the most recent
   development version of the Freenet core from GitHub and compiles it
@@ -429,6 +431,10 @@ CHANGELOG about stuff only interesting for developers
   the HTML of mvn.freenetproject.org sounds like it wasn't
   - if it in fact was and someone knows how to use it please let me
   know.
+
+  To ensure bugs in the decision whether to recompile can be spotted the
+  Travis script was also amended to print the version of the freenet.jar
+  the build is using (issue 7068).
 
 - 0006972: [Code quality] Rewrite README.md file for developers (xor)
 

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -454,6 +454,28 @@ CHANGELOG about stuff only interesting for developers
 
   Can be used to reproduce randomized test runs.
 
+- 0007019: [Code quality] Travis CI: Build against both fred branch next
+           and master (xor)
+
+  This ensures WoT works both with the current Freenet release and the one
+  which is in development.
+  Previously only the development one was tested.
+  While new plugin versions are usually released with a new Freenet
+  release, it is also possible to release them without one, so it's a good
+  idea to ensure WoT is stable against any fred branch.
+
+  An additional benefit of this is that the existing Travis code to upload
+  the resulting WoT JAR to a CHK now uses fred branch master instead of
+  next as well.
+  This means that the upload will now be downloadable for users of the
+  stable release in case the way data is stored on the network is changed
+  on the development codebase.
+  So fred developers won't have to build WoT on their own for releases if
+  they don't like to, they can just use the CHK from Travis CI.
+
+  To ensure the number of Travis CI builds doesn't grow excessively the
+  test against branch master only happens on a single Java version.
+
 THANKS TO
 
   - ArneBab

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -332,6 +332,24 @@ CHANGELOG about stuff only interesting for developers
   *and* tools to compare their results is a very sophisticated test,
   which is a benefit of its own.
 
+- 0007057: [Code quality] Make Eclipse project configuration use the new
+           Gradle builder (xor)
+
+  Bonus changes:
+
+  - This also ships a full rewrite of the Eclipse instructions
+    in the README.md - they explain step-by-step how Eclipse needs to be
+    configured to build, test and debug WoT with it.
+
+  - This notably includes instructions on how to generate an Eclipse
+    project configuration for fred and thereby be compatible with fred
+    versions above build01480: That is now necessary because during
+    replacement of Ant with Gradle the fred developers also removed the
+    Eclipse project from the repository.
+
+  - The Eclipse project configuration was updated to support a much more
+    recent Eclipse version (2018-12).
+
 - [Code quality] Travis CI: Test against most recent Java versions (xor)
 
   The cloud service now runs the unit tests periodically against:

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -428,6 +428,18 @@ CHANGELOG about stuff only interesting for developers
   - if it in fact was and someone knows how to use it please let me
   know.
 
+- 0006972: [Code quality] Rewrite README.md file for developers (xor)
+
+  The README in the Git repository was converted to GitHub markdown to
+  display with proper formatting on GitHub.
+  All information in it was reviewed and fixed to match how things work
+  currently.
+
+  The compilation, testing and debugging instructions have been amended
+  to e.g. explain special features such as benchmark scripts, test
+  scripts and test coverage analysis.
+  A concise yet complete description of the purpose of WoT was added.
+
 THANKS TO
 
   - ArneBab

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -334,17 +334,18 @@ CHANGELOG about stuff only interesting for developers
 - [Code quality] Travis CI: Test against most recent Java versions (xor)
 
   The cloud service now runs the unit tests periodically against:
-  - oraclejdk9
+  - oraclejdk11 (new)
   - oraclejdk8
+  - openjdk12 (new)
+  - openjdk11 (new)
   - openjdk10 (new)
   - openjdk9 (new)
   - openjdk8
   - openjdk7
 
-  This is the maximal set of Java versions which are both supported by
-  Freenet and Travis CI as of 2018-10-31.
-  Notably the new Java 11 is not tested yet due to Freenet's Gradle not
-  working on it.
+  This is the maximal set of Java versions which are supported by
+  Freenet, Travis CI and Oracle as of 2019-05-04.
+  (OpenJDK might not provide security updates for all of these.)
 
 - [Code quality] Travis CI: Speed up build time from 1 hour to
                  20 minutes (xor)

--- a/developer-documentation/changelogs/build0021.txt
+++ b/developer-documentation/changelogs/build0021.txt
@@ -448,6 +448,11 @@ CHANGELOG about stuff only interesting for developers
   scripts and test coverage analysis.
   A concise yet complete description of the purpose of WoT was added.
 
+- 0006987: [Code quality] Fix JUnit4 tests to the print name of the
+           currently running test when they print the seed (xor)
+
+  Can be used to reproduce randomized test runs.
+
 THANKS TO
 
   - ArneBab

--- a/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
+++ b/test/plugins/WebOfTrust/AbstractJUnit4BaseTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
 import com.db4o.ext.ExtObjectContainer;
 
@@ -54,6 +55,9 @@ public abstract class AbstractJUnit4BaseTest {
 			Configuration.IS_UNIT_TEST);
 	}
 
+
+    @Rule public final TestName mTestName = new TestName();
+
     protected RandomSource mRandom;
     
     @Rule
@@ -68,7 +72,8 @@ public abstract class AbstractJUnit4BaseTest {
         Random seedGenerator = new Random();
         long seed = seedGenerator.nextLong();
         mRandom = new DummyRandomSource(seed);
-        System.out.println(this + " Random seed: " + seed);
+        
+        System.out.println("Test " + mTestName.getMethodName() + "() using Random seed: " + seed);
     }
     
     /**

--- a/tools/benchmark-unit-tests-from-travis
+++ b/tools/benchmark-unit-tests-from-travis
@@ -7,8 +7,9 @@ trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 if [ $# != 1 ] ; then
 	echo "Syntax: $0 TRAVIS_CI_LOGFILE" >&2
 	echo "" >&2
-	echo "NOTICE: This script only works if you configure Travis CI to use Ant!" >&2
-	echo "The default Gradle builder does not measure test runtime." >&2
+	echo "NOTICE: This script only works upon log files of the Travis job which uses Ant!" >&2
+	echo "The Gradle builder which is used by the other jobs does not measure test runtime." >&2
+	echo "See the 'script:' section in .travis.yml for which job uses Ant." >&2
 	exit 1
 fi
 

--- a/tools/benchmark-unit-tests-from-travis
+++ b/tools/benchmark-unit-tests-from-travis
@@ -6,6 +6,9 @@ trap 'echo "Error at line $LINENO, exit code $?" >&2' ERR
 
 if [ $# != 1 ] ; then
 	echo "Syntax: $0 TRAVIS_CI_LOGFILE" >&2
+	echo "" >&2
+	echo "NOTICE: This script only works if you configure Travis CI to use Ant!" >&2
+	echo "The default Gradle builder does not measure test runtime." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
_Please merge with `--ff-only` into `next`._
_This also contains the commits of the previous PRs to that branch._

---

This finishes the adaption to Gradle.
Notably it also provides instructions on how to use fred with Eclipse (the fred developers have removed the Eclipse project from the repository so you need to create your own one now).