### PR TITLE
Travis CI: Fix branch master constantly failing due to new fred release

### DIFF
--- a/.travis.upload-jar-to-freenet.sh
+++ b/.travis.upload-jar-to-freenet.sh
@@ -56,9 +56,8 @@ echo "Uploading WoT JAR to $URI..."
 	done
 ) &
 
-# TODO: As of 2018-05-30 fcpupload's "--timeout" doesn't work, using coreutils' timeout, try again later
 # TODO: As of 2018-05-30 fcpupload's "--compress" also doesn't work.
-if ! time timeout 30m fcpupload --wait "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
+if ! time fcpupload --wait "$URI" "$TRAVIS_BUILD_DIR/dist/WebOfTrust.jar" ; then
 	echo "Uploading WebOfTrust.jar to Freenet failed!" >&2
 	
 	# The commented out lines are for debugging fcpupload's "--spawn".

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,15 @@ before_install:
 script: ant
 
 jdk:
-  - oraclejdk9
-  - oraclejdk8
   - openjdk8
-  - openjdk7
-  # openjdk9: As of 2018-05-12 isn't available on Travis yet.
-  # oraclejdk7: Not supported anymore: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - openjdk12
+  - openjdk13
+  - openjdk14
+  - oraclejdk13
+  - oraclejdk14
 
 deploy:
   provider: script
@@ -67,3 +70,4 @@ deploy:
   script: ./.travis.upload-jar-to-freenet.sh
   on:
     all_branches: true
+    condition: $TRAVIS_JDK_VERSION = openjdk8


### PR DESCRIPTION
_Please merge with `--ff-only` into `master`._

---

This is a exceptional **non-release** merge, normally only new WoT
releases are merged to master.

The goal of it is to fix constant build failures on Travis CI due to the
recent release of fred build 1485: Java 8 is now required for fred, so
compiling it against Java 7 would always fail on Travis CI.  
Therefore the Java versions we test on are updated by this branch.  
It also fixes bogus artifical build timeouts as they would become more
likely due to testing more Java versions at once.

I am hereby intentionally violating the standard of only pushing
releases to branch master because:
- The breakage was constant and would keep lasting for too much time
  until the next release is ready.
- This does not change the source code of the WoT binary itself.