### PR TITLE
IdentityFetcher-rewrite part 49: Prepare for fixing accuracy of XML processing time measurement

### DIFF
--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -212,10 +212,6 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 		// TODO: Performance: Avoid computing the filename from the URI twice by replacing
 		// get*Filename() with a single call to compute the filename without the dir, and then
 		// constructing two new File(dir, filename) for the two dirs.
-		// FIXME: Investigate if it would be possible to not additionally check the processing dir
-		// without causing IdentityDownloaderSlow to download the same file again while it is
-		// being processed. If we do remove the additional check then the FIXME related to files
-		// which are being processed at IdentityFileMemoryQueue.contains*() can be removed.
 		return getQueueFilename(identityFileURI).exists()
 		    || getProcessingDirFilename(identityFileURI).exists();
 	}

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -22,6 +22,15 @@ import freenet.support.Logger.LogLevel;
  * {@link IdentityFileQueue} implementation which writes the files to disk instead of keeping them
  * in memory.<br><br>
  * 
+ * NOTICE: While this implementation does preserve some files across restarts of WoT, it does not
+ * preserve all of them!  
+ * E.g. if a file had been {@link #poll()}ed during shutdown but processing of it had not been
+ * marked as finished by {@link IdentityFileStreamWrapper#close()} the file will be lost.  
+ * Thus users of this implementation must be safe against complete loss of the queue across
+ * restarts.  
+ * This is also demanded by the JavaDoc of the interface {@link IdentityFileQueue} for sophisticated
+ * reasons.
+ * 
  * Deduplicating queue: Only the latest edition of each file is returned; see
  * {@link IdentityFileQueue} for details.<br>
  * The order of files is not preserved.<br>
@@ -139,6 +148,8 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 		// Since there should only be 1 file at a time in processing, and lost files will
 		// automatically be downloaded again, we just delete it to avoid the hassle of writing code
 		// for moving it back.
+		// We are allowed to delete it by the parent interface IdentityFileQueue, it specifies that
+		// any queue content may be lost upon restart of WoT.
 		for(File file : mProcessingDir.listFiles()) {
 			if(!file.getName().endsWith(IdentityFile.FILE_EXTENSION)) {
 				Logger.warning(this, "cleanDirectories(): Unexpected file type: " + file);

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -36,6 +36,14 @@ import freenet.support.Logger.LogLevel;
  * The order of files is not preserved.<br>
  */
 final class IdentityFileDiskQueue implements IdentityFileQueue {
+
+	/** This number of files is calculated to result in at most ~ 1 GiB of disk usage considering
+	 *  the maximum size of each file.  
+	 *  The overhead for file headers was excluded from that for simplicity.
+	 *  @see IdentityFileQueue#getSizeSoftLimit() */
+	private static final int SIZE_SOFT_LIMIT_FILES
+		= (1024*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;
+
 	/** Subdirectory of WOT data directory where we put our data dirs. */
 	private final File mDataDir;
 
@@ -446,6 +454,10 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 	@Override public synchronized int getSize() {
 		assert(mStatistics.mQueuedFiles == mQueueDir.listFiles().length);
 		return mStatistics.mQueuedFiles;
+	}
+
+	@Override public int getSizeSoftLimit() {
+		return SIZE_SOFT_LIMIT_FILES;
 	}
 
 	private final class IdentityFileStreamWrapperImpl implements IdentityFileStreamWrapper {

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -145,11 +145,9 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 		// Processing dir policy:
 		// In theory we could move the files back to the queue. But its possible that a colliding
 		// filename exists there, which would need special code to handle.
-		// Since there should only be 1 file at a time in processing, and lost files will
-		// automatically be downloaded again, we just delete it to avoid the hassle of writing code
-		// for moving it back.
-		// We are allowed to delete it by the parent interface IdentityFileQueue, it specifies that
-		// any queue content may be lost upon restart of WoT.
+		// Since there should only be 1 file at a time in processing, and the parent interface's
+		// JavaDoc allows us to delete queue contents during restarts of WoT, we just delete it to
+		// avoid the hassle of writing code for moving it back.
 		for(File file : mProcessingDir.listFiles()) {
 			if(!file.getName().endsWith(IdentityFile.FILE_EXTENSION)) {
 				Logger.warning(this, "cleanDirectories(): Unexpected file type: " + file);

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -39,7 +39,10 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 
 	/** This number of files is calculated to result in at most ~ 1 GiB of disk usage considering
 	 *  the maximum size of each file.  
-	 *  The overhead for file headers was excluded from that for simplicity.
+	 *  The overhead for file headers was excluded from that for simplicity.  
+	 *  TODO: Make configurable through web interface. Also apply this to IdentityFileMemoryQueue
+	 *  (which is currently only used in tests, but perhaps some day someone adds an option to
+	 *  use it in production, so better have it correct now already).
 	 *  @see IdentityFileQueue#getSizeSoftLimit() */
 	private static final int SIZE_SOFT_LIMIT_FILES
 		= (1024*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;

--- a/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
@@ -28,6 +28,12 @@ import plugins.WebOfTrust.util.jobs.BackgroundJob;
  * and to warn users that they only should use it if they have lots of memory. */
 final class IdentityFileMemoryQueue implements IdentityFileQueue {
 
+	/** This number of files is calculated to result in at most ~ 128 MiB of memory usage
+	 *  considering the maximum size of each file.  
+	 *  @see IdentityFileQueue#getSizeSoftLimit() */
+	private static final int SIZE_SOFT_LIMIT_FILES
+		= (128*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;
+
 	private final LinkedList<IdentityFile> mQueue = new LinkedList<IdentityFile>();
 
 	private final IdentityFileQueueStatistics mStatistics = new IdentityFileQueueStatistics();
@@ -155,6 +161,10 @@ final class IdentityFileMemoryQueue implements IdentityFileQueue {
 	@Override public synchronized int getSize() {
 		assert(mStatistics.mQueuedFiles == mQueue.size());
 		return mStatistics.mQueuedFiles;
+	}
+
+	@Override public int getSizeSoftLimit() {
+		return SIZE_SOFT_LIMIT_FILES;
 	}
 
 	@Override public synchronized void registerEventHandler(BackgroundJob handler) {

--- a/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
@@ -43,8 +43,6 @@ final class IdentityFileMemoryQueue implements IdentityFileQueue {
 		
 		// FIXME: In opposite to IdentityFileDiksQueue.contains*(), this will NOT return true while
 		// the file is being processed! Determine if this causes any breakage of tests.
-		// Notice that there is a related FIXME at IdentityFileDiskQueue.contains*() which requests
-		// consideration of removal of the check if a file is being processed.
 		// EDIT: Recently IdentityFileStreamWrapper has been added to IdentityFileQueue, and poll()
 		// has been changed to return an instance of that. This will allow us to fix the issue
 		// easily because the goal behind IdentityFileStreamWrapper **is** to allow contains*() to

--- a/src/plugins/WebOfTrust/IdentityFileProcessor.java
+++ b/src/plugins/WebOfTrust/IdentityFileProcessor.java
@@ -233,8 +233,7 @@ public final class IdentityFileProcessor implements Daemon, DelayedBackgroundJob
 						break;
 					}
 				} finally {
-					if(streamWrapper != null)
-						Closer.close(streamWrapper); // Also closes the wrapped stream.
+					Closer.close(streamWrapper); // Also closes the wrapped stream.
 				}
 				
 				if(Thread.interrupted()) {

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -3,6 +3,7 @@
  * any later version). See http://www.gnu.org/ for details of the GPL. */
 package plugins.WebOfTrust;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -179,8 +179,8 @@ public interface IdentityFileQueue {
 	 *  - IdentityDownloader implementations may use up to O(N), with N = getSize(), calls to
 	 *    {@link #containsAnyEditionOf(FreenetURI)} to avoid starting downloads for Identitys for
 	 *    which we currently have an IdentityFile in the queue pending import.  
-	 *    If the queue was allowed to become very large then the N calls to that function would take
-	 *    too much time.  
+	 *    If the queue was allowed to become very large then the O(N) calls to that function would
+	 *    take too much time.  
 	 *    See {@link IdentityDownloaderSlow#run()} for details. */
 	public int getSizeSoftLimit();
 

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -67,7 +67,17 @@ public interface IdentityFileQueue {
 	 * 
 	 *     Closer.close(identityFileStream);
 	 *     
-	 * in class IdentityFileQueue (variables are named differently there, search for Closer). */
+	 * in class IdentityFileQueue (variables are named differently there, search for Closer).
+	 * 
+	 * TODO: Performance: {@link #mXMLInputStream} typically is a {@link ByteArrayInputStream}
+	 * (see {@link IdentityFileDiskQueue#poll()})), and the close() of that does NOT null the byte
+	 * array to allow garbage collection of it.  
+	 * But XMLTransformer.parseIdentityXML() calls close() very early, before importIdentity() even
+	 * tries to wait for the database transaction locks, so it would potentially free 1 MiB of
+	 * memory (max XML size) for quite a few seconds if close() DID free the array.  
+	 * Figure out a way to implement that. It seems possible to achieve by creating a subclass of
+	 * ByteArrayInputStream: That class doesn't declare its member variables private so we can
+	 * null them at will. */
 	public static final class IdentityFileStream {
 		public final FreenetURI mURI;
 

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -126,7 +126,11 @@ public interface IdentityFileQueue {
 	 * 
 	 * ATTENTION: Concurrent processing of multiple elements from the queue is not supported.
 	 * This means that the returned {@link IdentityFileStreamWrapper} must be closed before you call
-	 * {@link #poll()} the next time!
+	 * {@link #poll()} the next time!  
+	 * (It is not supported because in an {@link IdentityFileDiskQueue} the names of
+	 * {@link IdentityFile}s could collide inside the temporary directory for files in processing.  
+	 * Further the core of WoT does not support concurrent trust list import anyway so there's no
+	 * need for this feature.)
 	 * 
 	 * ATTENTION: You must only call {@link IdentityFileStreamWrapper#close()} **after**
 	 * processing the returned data is completely finished and committed to the database!
@@ -228,8 +232,8 @@ public interface IdentityFileQueue {
 		 * A file is considered to be in processing when it has been dequeued using
 		 * {@link IdentityFileQueue#poll()}, but the returned {@link IdentityFileStreamWrapper} has
 		 * not been closed yet.<br>
-		 * This number should only ever be 0 or 1 as required by {@link IdentityFileQueue#poll()}.
-		 * (Concurrent processing is not supported because the filenames could collide).<br><br>
+		 * This number should only ever be 0 or 1 as required by {@link IdentityFileQueue#poll()}'s
+		 * specification.
 		 * 
 		 * Notice: Queue implementations are free to not track this number, i.e. keep it at 0.<br>
 		 * Without warranty it can be said that {@link IdentityFileDiskQueue} does track this

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -163,7 +163,8 @@ public interface IdentityFileQueue {
 	public int getSize();
 
 	/** If {@link #getSize()} exceeds this limit {@link IdentityDownloader} implementations should
-	 *  not start any further downloads for {@link IdentityFile}s to add to the queue.
+	 *  not start any further downloads for {@link IdentityFile}s to
+	 *  {@link #add(IdentityFileStream)} to the queue.
 	 *  
 	 *  To ensure pending downloads can keep running it is a soft-limit, i.e. adding files to the
 	 *  queue will still succeed even if {@link #getSize()} is above the limit.
@@ -175,10 +176,12 @@ public interface IdentityFileQueue {
 	 *  - Currently an IdentityFile can be up to 1 MiB large (according to
 	 *    {@link XMLTransformer#MAX_IDENTITY_XML_BYTE_SIZE}) so we should not queue too many of them
 	 *    on disk / in memory.
-	 *  - IdentityDownloader implementations will typically use
-	 *    {@link #containsAnyEditionOf(FreenetURI)} to not start download for Identitys which are
-	 *    currently pending import - and if the queue becomes very large then all the calls to that
-	 *    function would take too much time. */
+	 *  - IdentityDownloader implementations may use up to O(N), with N = getSize(), calls to
+	 *    {@link #containsAnyEditionOf(FreenetURI)} to avoid starting downloads for Identitys for
+	 *    which we currently have an IdentityFile in the queue pending import.  
+	 *    If the queue was allowed to become very large then the N calls to that function would take
+	 *    too much time.  
+	 *    See {@link IdentityDownloaderSlow#run()} for details. */
 	public int getSizeSoftLimit();
 
 	/**

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -59,16 +59,8 @@ import plugins.WebOfTrust.util.jobs.BackgroundJob;
  * freenet.client.async.ClientGetter)}. */
 public interface IdentityFileQueue {
 	/**
-	 * TODO: Code quality: This should be a {@link FilterInputStream} to allow replacing
-	 * 
-	 *     if(identityFileStream != null)
-	 *         Closer.close(identityFileStream.mXMLInputStream);
-	 * 
-	 * with
-	 * 
-	 *     Closer.close(identityFileStream);
-	 *     
-	 * in class IdentityFileQueue (variables are named differently there, search for Closer).
+	 * TODO: Code quality: This should be a child class of {@link FilterInputStream} as that is the
+	 * standard way to add functionality to streams in Java.
 	 * 
 	 * TODO: Performance: {@link #mXMLInputStream} typically is a {@link ByteArrayInputStream}
 	 * (see {@link IdentityFileDiskQueue#poll()})), and the close() of that does NOT null the byte

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -4341,16 +4341,16 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 * }}}}
 	 * </code>
 	 * 
-	 * @param e The exception which triggered the abort. Will be logged to the Freenet log file.
+	 * @param t The throwable which triggered the abort. Will be logged to the Freenet log file.
 	 * @param logLevel The {@link LogLevel} to use when logging the abort to the Freenet log file.
 	 */
-	protected void abortTrustListImport(Exception e, LogLevel logLevel) {
+	protected void abortTrustListImport(Throwable t, LogLevel logLevel) {
 		if(logMINOR) Logger.minor(this, "abortTrustListImport()");
 		
 		assert(mTrustListImportInProgress);
 		mTrustListImportInProgress = false;
 		mFullScoreComputationNeeded = false;
-		Persistent.checkedRollback(mDB, this, e, logLevel);
+		Persistent.checkedRollback(mDB, this, t, logLevel);
 		assert(computeAllScoresWithoutCommit()); // Test rollback.
 	}
 	

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -460,6 +460,8 @@ public final class XMLTransformer {
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {
 		synchronized(mSubscriptionManager) {
+			stats.mImportTime = new StopWatch();
+			
 			final Identity identity;
 			try {
 				identity = mWoT.getIdentityByURI(identityURI);
@@ -486,6 +488,8 @@ public final class XMLTransformer {
                   + "IdentityFetcher has not processed the AbortFetchCommand yet or the "
                   + "file was in the IdentityFileQueue for some time, not importing: "
                   + identity);
+                
+                stats.mImportTime = null;
                 return;
             }
 			
@@ -514,6 +518,7 @@ public final class XMLTransformer {
 				} else {
 					Logger.warning(this,
 						"Fetched obsolete edition! Edition: " + newEdition + "; " + identity);
+					stats.mImportTime = null;
 					return;
 				}
 			}
@@ -816,7 +821,8 @@ public final class XMLTransformer {
 					throw e;
 				} // try
 			} // synchronized(Persistent.transactionLock(db))
-				
+			
+			stats.mImportTime.stop();
 			Logger.normal(this, "Finished XML import for " + identity);
 		} // synchronized(mSubscriptionManager)
 		} // synchronized(mWoT.getIdentityFetcher())
@@ -828,6 +834,9 @@ public final class XMLTransformer {
 			
 			if(stats.mXMLParsingTime != null)
 				stats.mXMLParsingTime.stopIfNotStoppedYet();
+			
+			if(stats.mImportTime != null)
+				stats.mImportTime.stopIfNotStoppedYet();
 			
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -357,7 +357,7 @@ public final class XMLTransformer {
 	/**
 	 * @param xmlInputStream An InputStream which must not return more than {@link MAX_IDENTITY_XML_BYTE_SIZE} bytes.
 	 */
-	private ParsedIdentityXML parseIdentityXML(InputStream xmlInputStream) throws IOException {
+	private ParsedIdentityXML parseIdentityXML(InputStream xmlInputStream) {
 		Logger.normal(this, "Parsing identity XML...");
 		
 		final ParsedIdentityXML result = new ParsedIdentityXML();

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -725,6 +725,15 @@ public final class XMLTransformer {
 										// Logging the exception does NOT log the actual malformed URL so we do it manually.
 										Logger.warning(this, "Received malformed identity URL: " + trusteeURI, urlEx);
 										throw urlEx;
+									} catch (InvalidParameterException ipEx) {
+										// This is likely impossible as currently the Identity
+										// constructor only throws this upon an invalid nickname,
+										// but we passed null for the nickname.
+										// TODO: Code quality: Add Identity constructor which
+										// doesn't require a nickname.
+										Logger.error(this, "Creating trustee failed for URI: "
+											+ trusteeURI, ipEx);
+										throw new RuntimeException(ipEx);
 									}
 								}
 							}

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -46,6 +46,7 @@ import plugins.WebOfTrust.exceptions.UnknownIdentityException;
 import plugins.WebOfTrust.introduction.IntroductionPuzzle;
 import plugins.WebOfTrust.network.input.EditionHint;
 import plugins.WebOfTrust.network.input.IdentityDownloaderController;
+import plugins.WebOfTrust.util.StopWatch;
 
 import com.db4o.ext.ExtObjectContainer;
 

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -420,8 +420,10 @@ public final class XMLTransformer {
 	 * - The trust list of the identity, if it has published one in the XML.
 	 * 
 	 * @param xmlInputStream The input stream containing the XML.
-	 */
-	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream) {
+	 * @throws OutOfMemoryError To indicate you should stop calling this function for a while. */
+	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
+			throws OutOfMemoryError {
+		
 		try { // Catch import problems so we can mark the edition as parsing failed
 		// We first parse the XML without synchronization, then do the synchronized import into the WebOfTrust		
 		final ParsedIdentityXML xmlData = parseIdentityXML(xmlInputStream);

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -446,8 +446,8 @@ public final class XMLTransformer {
 	 * 
 	 * @param xmlInputStream The input stream containing the XML.
 	 * @throws OutOfMemoryError To indicate you should stop calling this function for a while. */
-	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
-			throws OutOfMemoryError {
+	public ImportIdentityStatistics importIdentity(FreenetURI identityURI,
+			InputStream xmlInputStream) throws OutOfMemoryError {
 		
 		final ImportIdentityStatistics stats = new ImportIdentityStatistics();
 		
@@ -490,7 +490,7 @@ public final class XMLTransformer {
                   + identity);
                 
                 stats.mImportTime = null;
-                return;
+                return stats;
             }
 			
 			final long newEdition = identityURI.getEdition();
@@ -519,7 +519,7 @@ public final class XMLTransformer {
 					Logger.warning(this,
 						"Fetched obsolete edition! Edition: " + newEdition + "; " + identity);
 					stats.mImportTime = null;
-					return;
+					return stats;
 				}
 			}
 			
@@ -923,6 +923,10 @@ public final class XMLTransformer {
 			if(outOfMemoryError != null)
 				throw outOfMemoryError;
 		}
+		
+		assert(stats.mXMLParsingTime != null ? stats.mXMLParsingTime.wasStopped() : true);
+		assert(stats.mImportTime     != null ?     stats.mImportTime.wasStopped() : true);
+		return stats;
 	}
 
 	public void exportIntroduction(OwnIdentity identity, OutputStream os) throws TransformerException {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -745,8 +745,12 @@ public final class XMLTransformer {
 					mWoT.getIdentityDownloaderController().onNewEditionImported(identity);
 					identity.storeAndCommit();
 				}
-				catch(Exception e) { 
+				catch(Exception | Error e) {
 					mWoT.abortTrustListImport(e, Logger.LogLevel.WARNING); // Does the rollback
+					
+					// It is critically important to throw the throwable out: This makes the outer
+					// catch() mark the edition as ParsingFailed so it won't be downloaded again and
+					// again and thereby cause the same problems forever.
 					throw e;
 				} // try
 			} // synchronized(Persistent.transactionLock(db))
@@ -756,7 +760,7 @@ public final class XMLTransformer {
 		} // synchronized(mWoT.getIdentityFetcher())
 		} // synchronized(mWoT)
 		} // try
-		catch(Exception e) {
+		catch(Exception | Error e) {
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -741,9 +741,13 @@ public final class XMLTransformer {
 							}
 
 							if(trustee != null) {
-								// Also takes care of notifying the SubscriptionManager
-								mWoT.setTrustWithoutCommit(
-									identity, trustee, editionHint, trustValue, trustComment);
+								try {
+									// Also takes care of notifying the SubscriptionManager
+									mWoT.setTrustWithoutCommit(
+										identity, trustee, editionHint, trustValue, trustComment);
+								} catch(InvalidParameterException e) {
+									throw new ParseException("Received invalid trust: " + e, -1);
+								}
 							}
 						}
 

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -421,7 +421,22 @@ public final class XMLTransformer {
 		
 		return result;
 	}
-	
+
+	/** Measurements of execution time of {@link XMLTransformer#importIdentity(FreenetURI,
+	 *  InputStream)}.
+	 * 
+	 *  These notably do **not** include the time we wait to acquire the necessary database locks:  
+	 *  How long that takes does not measure the efficiency of our code, the locks will be blocked
+	 *  by other subsystems which are beyond our control. */
+	public static final class ImportIdentityStatistics {
+		/** Time it took to parse the XML, without any further processing.
+		 *  Null if parsing failed. */
+		public StopWatch mXMLParsingTime;
+		/** Time it took to import the data from the already parsed XML into the WoT database.
+		 *  Null if importing failed. */
+		public StopWatch mImportTime;
+	}
+
 	/**
 	 * Imports a identity XML file into the given web of trust. This includes:
 	 * - The identity itself and its attributes

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -747,7 +747,7 @@ public final class XMLTransformer {
 					mWoT.getIdentityDownloaderController().onNewEditionImported(identity);
 					identity.storeAndCommit();
 				}
-				catch(Exception | Error e) {
+				catch(RuntimeException | Error e) {
 					mWoT.abortTrustListImport(e, Logger.LogLevel.WARNING); // Does the rollback
 					
 					// It is critically important to throw the throwable out: This makes the outer
@@ -762,7 +762,7 @@ public final class XMLTransformer {
 		} // synchronized(mWoT.getIdentityFetcher())
 		} // synchronized(mWoT)
 		} // try
-		catch(Exception | Error e) {
+		catch(RuntimeException | Error e) {
 			OutOfMemoryError outOfMemoryError
 				= e instanceof OutOfMemoryError ? (OutOfMemoryError)e : null;
 			

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -433,6 +433,7 @@ public final class XMLTransformer {
 		/** Time it took to parse the XML, without any further processing.
 		 *  Null if parsing failed. */
 		public StopWatch mXMLParsingTime;
+
 		/** Time it took to import the data from the already parsed XML into the WoT database.
 		 *  Null if importing failed. */
 		public StopWatch mImportTime;

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -407,6 +407,14 @@ public final class XMLTransformer {
 			}
 		} catch(Throwable t) {
 			result.parseError = t;
+		} finally {
+			// Close the stream here already instead of expecting the callers to do it so we can
+			// alleviate potential OutOfMemoryErrors which large XML may cause.
+			try {
+				xmlInputStream.close();
+			} catch(Throwable t) {
+				Logger.warning(this, "xmlInputStream.close() failed!", t);
+			}
 		}
 		
 		Logger.normal(this, "Finished parsing identity XML.");

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -439,7 +439,13 @@ public final class XMLTransformer {
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {
 		synchronized(mSubscriptionManager) {
-			final Identity identity = mWoT.getIdentityByURI(identityURI);
+			final Identity identity;
+			try {
+				identity = mWoT.getIdentityByURI(identityURI);
+			} catch(UnknownIdentityException e) {
+				throw new RuntimeException(
+					"Downloaded XML for Identity which doesn't exist!? URI: " + identityURI, e);
+			}
 			final Identity oldIdentity = identity.clone(); // For the SubscriptionManager
 			
 			Logger.normal(this, "Importing parsed XML for " + identity);

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -826,6 +826,9 @@ public final class XMLTransformer {
 			OutOfMemoryError outOfMemoryError
 				= e instanceof OutOfMemoryError ? (OutOfMemoryError)e : null;
 			
+			if(stats.mXMLParsingTime != null)
+				stats.mXMLParsingTime.stopIfNotStoppedYet();
+			
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -487,8 +487,15 @@ public final class XMLTransformer {
 			if(xmlData.parseError != null) {
 				String message = "XML parsing failed for " + identityURI;
 				Logger.warning(this, message, xmlData.parseError);
-				// TODO: Code quality: Use a class which can consume the causing exception.
-				throw new ParseException(message, -1);
+				
+				if(xmlData.parseError instanceof OutOfMemoryError) {
+					// We have special code for handling OOM at the end of the function so pass it
+					// to that.
+					throw (OutOfMemoryError)xmlData.parseError;
+				} else {
+					// TODO: Code quality: Use a class which can consume the causing exception.
+					throw new ParseException(message, -1);
+				}
 			}
 			
 			synchronized(Persistent.transactionLock(mDB)) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -508,6 +508,7 @@ public final class XMLTransformer {
 					throw (OutOfMemoryError)xmlData.parseError;
 				} else {
 					// TODO: Code quality: Use a class which can consume the causing exception.
+					// Also applies to further usages of this class in this function.
 					throw new ParseException(message, -1);
 				}
 			}
@@ -723,8 +724,9 @@ public final class XMLTransformer {
 										Logger.normal(this, "New identity received via trust list: " + identity);
 									} catch(MalformedURLException urlEx) {
 										// Logging the exception does NOT log the actual malformed URL so we do it manually.
-										Logger.warning(this, "Received malformed identity URL: " + trusteeURI, urlEx);
-										throw urlEx;
+										String message = "Received malformed identity URL: " + trusteeURI;
+										Logger.warning(this, message, urlEx);
+										throw new ParseException(message, -1);
 									} catch (InvalidParameterException ipEx) {
 										// This is likely impossible as currently the Identity
 										// constructor only throws this upon an invalid nickname,

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -449,9 +449,13 @@ public final class XMLTransformer {
 	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
 			throws OutOfMemoryError {
 		
+		final ImportIdentityStatistics stats = new ImportIdentityStatistics();
+		
 		try { // Catch import problems so we can mark the edition as parsing failed
 		// We first parse the XML without synchronization, then do the synchronized import into the WebOfTrust		
+		stats.mXMLParsingTime = new StopWatch();
 		final ParsedIdentityXML xmlData = parseIdentityXML(xmlInputStream);
+		stats.mXMLParsingTime.stop();
 		
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -842,6 +842,8 @@ public final class XMLTransformer {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below
 			synchronized(Persistent.transactionLock(mDB) ) {
+				StopWatch markAsParsingFailedTime = new StopWatch();
+				
 				// FIXME: build0020 lacked a try/catch block to rollback the transaction upon error
 				// even though the old version of this code block also did multiple modifications to
 				// the Identity object and thus the database could become inconsistent if something
@@ -903,6 +905,12 @@ public final class XMLTransformer {
 						"also failed! URI: " + identityURI, doubleFault);
 					Persistent.checkedRollback(mDB, this, doubleFault);
 				}
+				
+				markAsParsingFailedTime.stop();
+				if(stats.mImportTime == null)
+					stats.mImportTime = markAsParsingFailedTime;
+				else
+					stats.mImportTime.add(markAsParsingFailedTime);
 			}
 			}
 			}

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -22,7 +22,7 @@ import freenet.keys.FreenetURI;
 /**
  * Downloads {@link Identity} objects from the P2P network.
  * Strictly all of them are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which
- * is consumed by the {@link IdentityFileProcessor}.
+ * the {@link IdentityFileProcessor} polls and feeds into the {@link XMLTransformer}.
  * 
  * Implementations must tolerate loss of the output {@link IdentityFileQueue} across restarts of
  * WoT as required by the JavaDoc of that interface!  

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -468,10 +468,14 @@ public interface IdentityDownloader extends Daemon {
 	 * To ensure already downloaded editions are not downloaded again in between onSuccess() and
 	 * onNewEditionImported() implementations should use
 	 * {@link IdentityFileQueue#containsAnyEditionOf(FreenetURI)} in their download scheduler to not
-	 * start a download for an Identity if that function returns true.   
+	 * start a download for an Identity if that function returns true and thereby indicates that
+	 * they've already downloaded an edition of that Identity.   
 	 * See the large documentation inside of {@link IdentityDownloaderSlow#onSuccess(
 	 * freenet.client.FetchResult, freenet.client.async.ClientGetter)} for why this whole design
 	 * pattern is a good idea.
+	 * As a side effect this design pattern also ensures collaboration among IdentityDownloaders:  
+	 * If one implementation downloads an edition, other implementations running in parallel may
+	 * avoid trying to download the same edition again.
 	 * 
 	 * Synchronization:
 	 * This function is guaranteed to be called while the following locks are being held in the

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -447,8 +447,8 @@ public interface IdentityDownloader extends Daemon {
 	void storeNewEditionHintCommandWithoutCommit(EditionHint hint);
 
 	/**
-	 * Called by the {@link XMLTransformer} after we've finished importing a new edition of an
-	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to it by an
+	 * Called by the {@link XMLTransformer} after it has imported a new edition of an
+	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to the queue by an
 	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
 	 * 

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -451,6 +451,8 @@ public interface IdentityDownloader extends Daemon {
 	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to the queue by an
 	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
+	 * FIXME: What about OwnIdentitys, should the IdentityInserter call it so we don't download
+	 * their editions after upload?
 	 * 
 	 * The {@link IdentityDownloader} interface JavaDoc requires IdentityDownloader implementations
 	 * as a whole to be safe against loss of the output {@link IdentityFileQueue} upon restarts of

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -448,8 +448,8 @@ public interface IdentityDownloader extends Daemon {
 
 	/**
 	 * Called by the {@link XMLTransformer} after we've finished importing a new edition of an
-	 * {@link Identity} (which has been downloaded by an IdentityDownloader implementation before
-	 * import).  
+	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to it by an
+	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
 	 * 
 	 * The {@link IdentityDownloader} interface JavaDoc requires IdentityDownloader implementations

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -694,6 +694,8 @@ public final class IdentityDownloaderSlow implements
 					// doing excessive I/O:
 					// Then we're querying very many hints from the database for getting little
 					// useful ones.
+					// This issue is what we're trying to limit by obeying
+					// mOutputQueue.getSizeSoftLimit() at the beginning of the function.
 					Logger.minor(this, "run(): Ignored hints: " + ignoredHints);
 					
 					Logger.minor(this,

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -553,7 +553,8 @@ public final class IdentityDownloaderSlow implements
 		// complete after the queue is full already.
 		if(mOutputQueue.getSize() > mOutputQueue.getSizeSoftLimit()) {
 			if(logMINOR) {
-				Logger.minor(this, "mOutputQueue too full, not starting new downloads, getSize(): "
+				Logger.minor(this,
+					"run(): mOutputQueue too full, not starting new downloads, getSize(): "
 					+ mOutputQueue.getSize());
 			}
 			// FIXME: Use an intelligent delay instead of a fixed one, e.g.:
@@ -680,7 +681,7 @@ public final class IdentityDownloaderSlow implements
 						if(--downloadsToSchedule <= 0)
 							break;
 					} catch(FetchException e) {
-						Logger.error(this, "FetchException for: " + h, e);
+						Logger.error(this, "run(): FetchException for: " + h, e);
 					}
 					
 					if(currentThread().isInterrupted()) {

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -545,20 +545,21 @@ public final class IdentityDownloaderSlow implements
 		//
 		// Notice: This is intentionally done *outside* of the below synchronized() blocks even
 		// though the size of the queue may be different until we acquire the locks. That is
-		// necessary because mOutputQueue.getSizeSoftLimit() takes the lock of the queue and for
-		// that WoT currently has no locking order convention (to avoid deadlocks) in relation to
-		// the locks taken below.
+		// necessary because mOutputQueue.getSize() takes the lock of the queue and for that WoT
+		// currently has no locking order convention (to avoid deadlocks) in relation to the locks
+		// taken below.
 		// The queue potentially growing meanwhile is not an issue because the "Soft" part of the
-		// queue size limit is to allow some leeway for running downloads.
+		// queue size limit is to allow some leeway for already running downloads which may
+		// complete after the queue is full already.
 		if(mOutputQueue.getSize() > mOutputQueue.getSizeSoftLimit()) {
 			if(logMINOR) {
 				Logger.minor(this, "mOutputQueue too full, not starting new downloads, getSize(): "
 					+ mOutputQueue.getSize());
 			}
-			// FIXME: Use a more intelligent delay, e.g.:
+			// FIXME: Use an intelligent delay instead of a fixed one, e.g.:
 			// - IdentityFileProcessor computes the average time it takes to process a file.
-			//   Divide the queue size by that to get the time until it will be empty, and use that
-			//   as delay.
+			//   Multiply the queue size by that to get the time until it will be empty, and use
+			//   that as delay.
 			// - Refine the above by computing the time until only a small amount of files is left
 			//   in the queue and use that as delay. Once the delay is over, and we run here and
 			//   see that the queue size is that small, sleep for only 1 second, check if it is

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -847,6 +847,8 @@ public final class IdentityDownloaderSlow implements
 			// because the files aren't available for import anymore. This also causes
 			// WebOfTrust.db4o to not be self-contained anymore, our defrag code and users would
 			// also have to copy the queue directory for backup purposes.
+			// EDIT: Actually the IdentityFileDiskQueue even by design deletes files in its
+			// temporary directory mProcessingDir after WoT has been restarted!
 			// There are two potential fixes:
 			// 1. Ensure the IdentityFileDiskQueue does fsync before returning from the above add().
 			//    This doesn't fix the backup code though and is still not 100% theoretically

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -38,6 +38,7 @@ public final class StopWatch {
 	}
 
 	public void divideNanosBy(long divisor) {
+		stopIfNotStoppedYet();
 		mStopTime = mStartTime + (mStopTime - mStartTime) / divisor;
 	}
 

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -3,9 +3,8 @@
  * any later version). See http://www.gnu.org/ for details of the GPL. */
 package plugins.WebOfTrust.util;
 
-import java.util.concurrent.TimeUnit;
-
-import freenet.support.TimeUtil;
+import static freenet.support.TimeUtil.formatTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /** Utility class for measuring execution time of code. */
 public final class StopWatch {
@@ -43,7 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(getNanos()), 3, true);
+		return formatTime(NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
 }

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -45,4 +45,9 @@ public final class StopWatch {
 		return formatTime(NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
+	public void add(StopWatch other) {
+		stopIfNotStoppedYet();
+		mStopTime += other.getNanos();
+	}
+
 }

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -23,6 +23,11 @@ public final class StopWatch {
 		mStopTime = System.nanoTime();
 	}
 
+	public void stopIfNotStoppedYet() {
+		if(!wasStopped())
+			stop();
+	}
+
 	public boolean wasStopped() {
 		return mStopTime != null;
 	}

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -23,6 +23,10 @@ public final class StopWatch {
 		mStopTime = System.nanoTime();
 	}
 
+	public boolean wasStopped() {
+		return mStopTime != null;
+	}
+
 	public long getNanos() {
 		if(mStopTime == null)
 			stop();

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -33,9 +33,7 @@ public final class StopWatch {
 	}
 
 	public long getNanos() {
-		if(mStopTime == null)
-			stop();
-		
+		stopIfNotStoppedYet();
 		return mStopTime - mStartTime;
 	}
 
@@ -44,9 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		if(mStopTime == null)
-			stop();
-		
+		stopIfNotStoppedYet();
 		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(mStopTime - mStartTime), 3, true);
 	}
 

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -42,8 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		stopIfNotStoppedYet();
-		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(mStopTime - mStartTime), 3, true);
+		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
 }


### PR DESCRIPTION
_Please merge with `--ff-only` into `issue-0003816-IdentityFetcher-rewrite`._
_This also contains the commits of the previous PRs to that branch._

---

Which is in turn to prepare for using it as input to intelligently control the
delay after which we download more XML files.