### PR TITLE
IdentityFetcher-rewrite part 51: Finish resolving large FIXME in IdentityDownloaderSlow.onSuccess(), begin recycling it into documentation

### DIFF
--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -36,6 +36,14 @@ import freenet.support.Logger.LogLevel;
  * The order of files is not preserved.<br>
  */
 final class IdentityFileDiskQueue implements IdentityFileQueue {
+
+	/** This number of files is calculated to result in at most ~ 1 GiB of disk usage considering
+	 *  the maximum size of each file.  
+	 *  The overhead for file headers was excluded from that for simplicity.
+	 *  @see IdentityFileQueue#getSizeSoftLimit() */
+	private static final int SIZE_SOFT_LIMIT_FILES
+		= (1024*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;
+
 	/** Subdirectory of WOT data directory where we put our data dirs. */
 	private final File mDataDir;
 
@@ -446,6 +454,10 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 	@Override public synchronized int getSize() {
 		assert(mStatistics.mQueuedFiles == mQueueDir.listFiles().length);
 		return mStatistics.mQueuedFiles;
+	}
+
+	@Override public int getSizeSoftLimit() {
+		return SIZE_SOFT_LIMIT_FILES;
 	}
 
 	private final class IdentityFileStreamWrapperImpl implements IdentityFileStreamWrapper {

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -145,11 +145,9 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 		// Processing dir policy:
 		// In theory we could move the files back to the queue. But its possible that a colliding
 		// filename exists there, which would need special code to handle.
-		// Since there should only be 1 file at a time in processing, and lost files will
-		// automatically be downloaded again, we just delete it to avoid the hassle of writing code
-		// for moving it back.
-		// We are allowed to delete it by the parent interface IdentityFileQueue, it specifies that
-		// any queue content may be lost upon restart of WoT.
+		// Since there should only be 1 file at a time in processing, and the parent interface's
+		// JavaDoc allows us to delete queue contents during restarts of WoT, we just delete it to
+		// avoid the hassle of writing code for moving it back.
 		for(File file : mProcessingDir.listFiles()) {
 			if(!file.getName().endsWith(IdentityFile.FILE_EXTENSION)) {
 				Logger.warning(this, "cleanDirectories(): Unexpected file type: " + file);

--- a/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileDiskQueue.java
@@ -39,7 +39,10 @@ final class IdentityFileDiskQueue implements IdentityFileQueue {
 
 	/** This number of files is calculated to result in at most ~ 1 GiB of disk usage considering
 	 *  the maximum size of each file.  
-	 *  The overhead for file headers was excluded from that for simplicity.
+	 *  The overhead for file headers was excluded from that for simplicity.  
+	 *  TODO: Make configurable through web interface. Also apply this to IdentityFileMemoryQueue
+	 *  (which is currently only used in tests, but perhaps some day someone adds an option to
+	 *  use it in production, so better have it correct now already).
 	 *  @see IdentityFileQueue#getSizeSoftLimit() */
 	private static final int SIZE_SOFT_LIMIT_FILES
 		= (1024*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;

--- a/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileMemoryQueue.java
@@ -28,6 +28,12 @@ import plugins.WebOfTrust.util.jobs.BackgroundJob;
  * and to warn users that they only should use it if they have lots of memory. */
 final class IdentityFileMemoryQueue implements IdentityFileQueue {
 
+	/** This number of files is calculated to result in at most ~ 128 MiB of memory usage
+	 *  considering the maximum size of each file.  
+	 *  @see IdentityFileQueue#getSizeSoftLimit() */
+	private static final int SIZE_SOFT_LIMIT_FILES
+		= (128*1024*1024) / XMLTransformer.MAX_IDENTITY_XML_BYTE_SIZE;
+
 	private final LinkedList<IdentityFile> mQueue = new LinkedList<IdentityFile>();
 
 	private final IdentityFileQueueStatistics mStatistics = new IdentityFileQueueStatistics();
@@ -155,6 +161,10 @@ final class IdentityFileMemoryQueue implements IdentityFileQueue {
 	@Override public synchronized int getSize() {
 		assert(mStatistics.mQueuedFiles == mQueue.size());
 		return mStatistics.mQueuedFiles;
+	}
+
+	@Override public int getSizeSoftLimit() {
+		return SIZE_SOFT_LIMIT_FILES;
 	}
 
 	@Override public synchronized void registerEventHandler(BackgroundJob handler) {

--- a/src/plugins/WebOfTrust/IdentityFileProcessor.java
+++ b/src/plugins/WebOfTrust/IdentityFileProcessor.java
@@ -79,14 +79,14 @@ public final class IdentityFileProcessor implements Daemon, DelayedBackgroundJob
 		/** Total time it took to process all {@link #mProcessedFiles}. */
 		public long mProcessingTimeNanoseconds = 0;
 
-		/**
-		 * Gets the average time it took for processing a file, in seconds. This is rather crude as
-		 * it includes all of those:<br>
-		 * - The time to acquire all locks, which could be a lot if WOT is busy.<br>
-		 * - The time to parse the XML.<br>
-		 * - The time to do Score recomputations.<br>
-		 * (There is a FIXME in {@link IdentityFileProcessor.Processor#run()} to improve this).<br>
-		 * <br>
+		/** Gets the average time it took for processing a file, in seconds. This includes only the
+		 *  most significant computations:
+		 *  - The time to parse the XML.
+		 *  - The time to import the XML to the database and do the resulting Score recomputations.
+		 *  
+		 *  In other words, it excludes things which cannot be optimized much such as:
+		 *  - Time for loading the file from disk.
+		 *  - Time spent waiting to acquire the necessary locks.
 		 * 
 		 * ATTENTION: Not synchronized - only use this if you are sure that the Statistics object is
 		 * not being modified anymore. This is the case if you obtained it using

--- a/src/plugins/WebOfTrust/IdentityFileProcessor.java
+++ b/src/plugins/WebOfTrust/IdentityFileProcessor.java
@@ -4,6 +4,7 @@
 package plugins.WebOfTrust;
 
 import static freenet.support.TimeUtil.formatTime;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.concurrent.TimeUnit;
 
@@ -94,8 +95,8 @@ public final class IdentityFileProcessor implements Daemon, DelayedBackgroundJob
 		public double getAverageXMLImportTime() {
 			if (mProcessedFiles == 0) // prevent division by 0
 				return 0;
-
-			return ((double) mProcessingTimeNanoseconds / (1000 * 1000 * 1000))
+			
+			return ((double) mProcessingTimeNanoseconds / (double) SECONDS.toNanos(1))
 				/ (double) mProcessedFiles;
 		}
 

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -3,6 +3,7 @@
  * any later version). See http://www.gnu.org/ for details of the GPL. */
 package plugins.WebOfTrust;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -179,8 +179,8 @@ public interface IdentityFileQueue {
 	 *  - IdentityDownloader implementations may use up to O(N), with N = getSize(), calls to
 	 *    {@link #containsAnyEditionOf(FreenetURI)} to avoid starting downloads for Identitys for
 	 *    which we currently have an IdentityFile in the queue pending import.  
-	 *    If the queue was allowed to become very large then the N calls to that function would take
-	 *    too much time.  
+	 *    If the queue was allowed to become very large then the O(N) calls to that function would
+	 *    take too much time.  
 	 *    See {@link IdentityDownloaderSlow#run()} for details. */
 	public int getSizeSoftLimit();
 

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -67,7 +67,17 @@ public interface IdentityFileQueue {
 	 * 
 	 *     Closer.close(identityFileStream);
 	 *     
-	 * in class IdentityFileQueue (variables are named differently there, search for Closer). */
+	 * in class IdentityFileQueue (variables are named differently there, search for Closer).
+	 * 
+	 * TODO: Performance: {@link #mXMLInputStream} typically is a {@link ByteArrayInputStream}
+	 * (see {@link IdentityFileDiskQueue#poll()})), and the close() of that does NOT null the byte
+	 * array to allow garbage collection of it.  
+	 * But XMLTransformer.parseIdentityXML() calls close() very early, before importIdentity() even
+	 * tries to wait for the database transaction locks, so it would potentially free 1 MiB of
+	 * memory (max XML size) for quite a few seconds if close() DID free the array.  
+	 * Figure out a way to implement that. It seems possible to achieve by creating a subclass of
+	 * ByteArrayInputStream: That class doesn't declare its member variables private so we can
+	 * null them at will. */
 	public static final class IdentityFileStream {
 		public final FreenetURI mURI;
 

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -163,7 +163,8 @@ public interface IdentityFileQueue {
 	public int getSize();
 
 	/** If {@link #getSize()} exceeds this limit {@link IdentityDownloader} implementations should
-	 *  not start any further downloads for {@link IdentityFile}s to add to the queue.
+	 *  not start any further downloads for {@link IdentityFile}s to
+	 *  {@link #add(IdentityFileStream)} to the queue.
 	 *  
 	 *  To ensure pending downloads can keep running it is a soft-limit, i.e. adding files to the
 	 *  queue will still succeed even if {@link #getSize()} is above the limit.
@@ -175,10 +176,12 @@ public interface IdentityFileQueue {
 	 *  - Currently an IdentityFile can be up to 1 MiB large (according to
 	 *    {@link XMLTransformer#MAX_IDENTITY_XML_BYTE_SIZE}) so we should not queue too many of them
 	 *    on disk / in memory.
-	 *  - IdentityDownloader implementations will typically use
-	 *    {@link #containsAnyEditionOf(FreenetURI)} to not start download for Identitys which are
-	 *    currently pending import - and if the queue becomes very large then all the calls to that
-	 *    function would take too much time. */
+	 *  - IdentityDownloader implementations may use up to O(N), with N = getSize(), calls to
+	 *    {@link #containsAnyEditionOf(FreenetURI)} to avoid starting downloads for Identitys for
+	 *    which we currently have an IdentityFile in the queue pending import.  
+	 *    If the queue was allowed to become very large then the N calls to that function would take
+	 *    too much time.  
+	 *    See {@link IdentityDownloaderSlow#run()} for details. */
 	public int getSizeSoftLimit();
 
 	/**

--- a/src/plugins/WebOfTrust/IdentityFileQueue.java
+++ b/src/plugins/WebOfTrust/IdentityFileQueue.java
@@ -59,16 +59,8 @@ import plugins.WebOfTrust.util.jobs.BackgroundJob;
  * freenet.client.async.ClientGetter)}. */
 public interface IdentityFileQueue {
 	/**
-	 * TODO: Code quality: This should be a {@link FilterInputStream} to allow replacing
-	 * 
-	 *     if(identityFileStream != null)
-	 *         Closer.close(identityFileStream.mXMLInputStream);
-	 * 
-	 * with
-	 * 
-	 *     Closer.close(identityFileStream);
-	 *     
-	 * in class IdentityFileQueue (variables are named differently there, search for Closer).
+	 * TODO: Code quality: This should be a child class of {@link FilterInputStream} as that is the
+	 * standard way to add functionality to streams in Java.
 	 * 
 	 * TODO: Performance: {@link #mXMLInputStream} typically is a {@link ByteArrayInputStream}
 	 * (see {@link IdentityFileDiskQueue#poll()})), and the close() of that does NOT null the byte

--- a/src/plugins/WebOfTrust/WebOfTrust.java
+++ b/src/plugins/WebOfTrust/WebOfTrust.java
@@ -4341,16 +4341,16 @@ public final class WebOfTrust extends WebOfTrustInterface
 	 * }}}}
 	 * </code>
 	 * 
-	 * @param e The exception which triggered the abort. Will be logged to the Freenet log file.
+	 * @param t The throwable which triggered the abort. Will be logged to the Freenet log file.
 	 * @param logLevel The {@link LogLevel} to use when logging the abort to the Freenet log file.
 	 */
-	protected void abortTrustListImport(Exception e, LogLevel logLevel) {
+	protected void abortTrustListImport(Throwable t, LogLevel logLevel) {
 		if(logMINOR) Logger.minor(this, "abortTrustListImport()");
 		
 		assert(mTrustListImportInProgress);
 		mTrustListImportInProgress = false;
 		mFullScoreComputationNeeded = false;
-		Persistent.checkedRollback(mDB, this, e, logLevel);
+		Persistent.checkedRollback(mDB, this, t, logLevel);
 		assert(computeAllScoresWithoutCommit()); // Test rollback.
 	}
 	

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -460,6 +460,8 @@ public final class XMLTransformer {
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {
 		synchronized(mSubscriptionManager) {
+			stats.mImportTime = new StopWatch();
+			
 			final Identity identity;
 			try {
 				identity = mWoT.getIdentityByURI(identityURI);
@@ -486,6 +488,8 @@ public final class XMLTransformer {
                   + "IdentityFetcher has not processed the AbortFetchCommand yet or the "
                   + "file was in the IdentityFileQueue for some time, not importing: "
                   + identity);
+                
+                stats.mImportTime = null;
                 return;
             }
 			
@@ -514,6 +518,7 @@ public final class XMLTransformer {
 				} else {
 					Logger.warning(this,
 						"Fetched obsolete edition! Edition: " + newEdition + "; " + identity);
+					stats.mImportTime = null;
 					return;
 				}
 			}
@@ -816,7 +821,8 @@ public final class XMLTransformer {
 					throw e;
 				} // try
 			} // synchronized(Persistent.transactionLock(db))
-				
+			
+			stats.mImportTime.stop();
 			Logger.normal(this, "Finished XML import for " + identity);
 		} // synchronized(mSubscriptionManager)
 		} // synchronized(mWoT.getIdentityFetcher())
@@ -828,6 +834,9 @@ public final class XMLTransformer {
 			
 			if(stats.mXMLParsingTime != null)
 				stats.mXMLParsingTime.stopIfNotStoppedYet();
+			
+			if(stats.mImportTime != null)
+				stats.mImportTime.stopIfNotStoppedYet();
 			
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -357,7 +357,7 @@ public final class XMLTransformer {
 	/**
 	 * @param xmlInputStream An InputStream which must not return more than {@link MAX_IDENTITY_XML_BYTE_SIZE} bytes.
 	 */
-	private ParsedIdentityXML parseIdentityXML(InputStream xmlInputStream) throws IOException {
+	private ParsedIdentityXML parseIdentityXML(InputStream xmlInputStream) {
 		Logger.normal(this, "Parsing identity XML...");
 		
 		final ParsedIdentityXML result = new ParsedIdentityXML();

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -725,6 +725,15 @@ public final class XMLTransformer {
 										// Logging the exception does NOT log the actual malformed URL so we do it manually.
 										Logger.warning(this, "Received malformed identity URL: " + trusteeURI, urlEx);
 										throw urlEx;
+									} catch (InvalidParameterException ipEx) {
+										// This is likely impossible as currently the Identity
+										// constructor only throws this upon an invalid nickname,
+										// but we passed null for the nickname.
+										// TODO: Code quality: Add Identity constructor which
+										// doesn't require a nickname.
+										Logger.error(this, "Creating trustee failed for URI: "
+											+ trusteeURI, ipEx);
+										throw new RuntimeException(ipEx);
 									}
 								}
 							}

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -46,6 +46,7 @@ import plugins.WebOfTrust.exceptions.UnknownIdentityException;
 import plugins.WebOfTrust.introduction.IntroductionPuzzle;
 import plugins.WebOfTrust.network.input.EditionHint;
 import plugins.WebOfTrust.network.input.IdentityDownloaderController;
+import plugins.WebOfTrust.util.StopWatch;
 
 import com.db4o.ext.ExtObjectContainer;
 

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -420,8 +420,10 @@ public final class XMLTransformer {
 	 * - The trust list of the identity, if it has published one in the XML.
 	 * 
 	 * @param xmlInputStream The input stream containing the XML.
-	 */
-	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream) {
+	 * @throws OutOfMemoryError To indicate you should stop calling this function for a while. */
+	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
+			throws OutOfMemoryError {
+		
 		try { // Catch import problems so we can mark the edition as parsing failed
 		// We first parse the XML without synchronization, then do the synchronized import into the WebOfTrust		
 		final ParsedIdentityXML xmlData = parseIdentityXML(xmlInputStream);

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -446,8 +446,8 @@ public final class XMLTransformer {
 	 * 
 	 * @param xmlInputStream The input stream containing the XML.
 	 * @throws OutOfMemoryError To indicate you should stop calling this function for a while. */
-	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
-			throws OutOfMemoryError {
+	public ImportIdentityStatistics importIdentity(FreenetURI identityURI,
+			InputStream xmlInputStream) throws OutOfMemoryError {
 		
 		final ImportIdentityStatistics stats = new ImportIdentityStatistics();
 		
@@ -490,7 +490,7 @@ public final class XMLTransformer {
                   + identity);
                 
                 stats.mImportTime = null;
-                return;
+                return stats;
             }
 			
 			final long newEdition = identityURI.getEdition();
@@ -519,7 +519,7 @@ public final class XMLTransformer {
 					Logger.warning(this,
 						"Fetched obsolete edition! Edition: " + newEdition + "; " + identity);
 					stats.mImportTime = null;
-					return;
+					return stats;
 				}
 			}
 			
@@ -923,6 +923,10 @@ public final class XMLTransformer {
 			if(outOfMemoryError != null)
 				throw outOfMemoryError;
 		}
+		
+		assert(stats.mXMLParsingTime != null ? stats.mXMLParsingTime.wasStopped() : true);
+		assert(stats.mImportTime     != null ?     stats.mImportTime.wasStopped() : true);
+		return stats;
 	}
 
 	public void exportIntroduction(OwnIdentity identity, OutputStream os) throws TransformerException {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -745,8 +745,12 @@ public final class XMLTransformer {
 					mWoT.getIdentityDownloaderController().onNewEditionImported(identity);
 					identity.storeAndCommit();
 				}
-				catch(Exception e) { 
+				catch(Exception | Error e) {
 					mWoT.abortTrustListImport(e, Logger.LogLevel.WARNING); // Does the rollback
+					
+					// It is critically important to throw the throwable out: This makes the outer
+					// catch() mark the edition as ParsingFailed so it won't be downloaded again and
+					// again and thereby cause the same problems forever.
 					throw e;
 				} // try
 			} // synchronized(Persistent.transactionLock(db))
@@ -756,7 +760,7 @@ public final class XMLTransformer {
 		} // synchronized(mWoT.getIdentityFetcher())
 		} // synchronized(mWoT)
 		} // try
-		catch(Exception e) {
+		catch(Exception | Error e) {
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -741,9 +741,13 @@ public final class XMLTransformer {
 							}
 
 							if(trustee != null) {
-								// Also takes care of notifying the SubscriptionManager
-								mWoT.setTrustWithoutCommit(
-									identity, trustee, editionHint, trustValue, trustComment);
+								try {
+									// Also takes care of notifying the SubscriptionManager
+									mWoT.setTrustWithoutCommit(
+										identity, trustee, editionHint, trustValue, trustComment);
+								} catch(InvalidParameterException e) {
+									throw new ParseException("Received invalid trust: " + e, -1);
+								}
 							}
 						}
 

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -421,7 +421,22 @@ public final class XMLTransformer {
 		
 		return result;
 	}
-	
+
+	/** Measurements of execution time of {@link XMLTransformer#importIdentity(FreenetURI,
+	 *  InputStream)}.
+	 * 
+	 *  These notably do **not** include the time we wait to acquire the necessary database locks:  
+	 *  How long that takes does not measure the efficiency of our code, the locks will be blocked
+	 *  by other subsystems which are beyond our control. */
+	public static final class ImportIdentityStatistics {
+		/** Time it took to parse the XML, without any further processing.
+		 *  Null if parsing failed. */
+		public StopWatch mXMLParsingTime;
+		/** Time it took to import the data from the already parsed XML into the WoT database.
+		 *  Null if importing failed. */
+		public StopWatch mImportTime;
+	}
+
 	/**
 	 * Imports a identity XML file into the given web of trust. This includes:
 	 * - The identity itself and its attributes

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -747,7 +747,7 @@ public final class XMLTransformer {
 					mWoT.getIdentityDownloaderController().onNewEditionImported(identity);
 					identity.storeAndCommit();
 				}
-				catch(Exception | Error e) {
+				catch(RuntimeException | Error e) {
 					mWoT.abortTrustListImport(e, Logger.LogLevel.WARNING); // Does the rollback
 					
 					// It is critically important to throw the throwable out: This makes the outer
@@ -762,7 +762,7 @@ public final class XMLTransformer {
 		} // synchronized(mWoT.getIdentityFetcher())
 		} // synchronized(mWoT)
 		} // try
-		catch(Exception | Error e) {
+		catch(RuntimeException | Error e) {
 			OutOfMemoryError outOfMemoryError
 				= e instanceof OutOfMemoryError ? (OutOfMemoryError)e : null;
 			

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -433,6 +433,7 @@ public final class XMLTransformer {
 		/** Time it took to parse the XML, without any further processing.
 		 *  Null if parsing failed. */
 		public StopWatch mXMLParsingTime;
+
 		/** Time it took to import the data from the already parsed XML into the WoT database.
 		 *  Null if importing failed. */
 		public StopWatch mImportTime;

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -407,6 +407,14 @@ public final class XMLTransformer {
 			}
 		} catch(Throwable t) {
 			result.parseError = t;
+		} finally {
+			// Close the stream here already instead of expecting the callers to do it so we can
+			// alleviate potential OutOfMemoryErrors which large XML may cause.
+			try {
+				xmlInputStream.close();
+			} catch(Throwable t) {
+				Logger.warning(this, "xmlInputStream.close() failed!", t);
+			}
 		}
 		
 		Logger.normal(this, "Finished parsing identity XML.");

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -439,7 +439,13 @@ public final class XMLTransformer {
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {
 		synchronized(mSubscriptionManager) {
-			final Identity identity = mWoT.getIdentityByURI(identityURI);
+			final Identity identity;
+			try {
+				identity = mWoT.getIdentityByURI(identityURI);
+			} catch(UnknownIdentityException e) {
+				throw new RuntimeException(
+					"Downloaded XML for Identity which doesn't exist!? URI: " + identityURI, e);
+			}
 			final Identity oldIdentity = identity.clone(); // For the SubscriptionManager
 			
 			Logger.normal(this, "Importing parsed XML for " + identity);

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -826,6 +826,9 @@ public final class XMLTransformer {
 			OutOfMemoryError outOfMemoryError
 				= e instanceof OutOfMemoryError ? (OutOfMemoryError)e : null;
 			
+			if(stats.mXMLParsingTime != null)
+				stats.mXMLParsingTime.stopIfNotStoppedYet();
+			
 			synchronized(mWoT) {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -487,8 +487,15 @@ public final class XMLTransformer {
 			if(xmlData.parseError != null) {
 				String message = "XML parsing failed for " + identityURI;
 				Logger.warning(this, message, xmlData.parseError);
-				// TODO: Code quality: Use a class which can consume the causing exception.
-				throw new ParseException(message, -1);
+				
+				if(xmlData.parseError instanceof OutOfMemoryError) {
+					// We have special code for handling OOM at the end of the function so pass it
+					// to that.
+					throw (OutOfMemoryError)xmlData.parseError;
+				} else {
+					// TODO: Code quality: Use a class which can consume the causing exception.
+					throw new ParseException(message, -1);
+				}
 			}
 			
 			synchronized(Persistent.transactionLock(mDB)) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -508,6 +508,7 @@ public final class XMLTransformer {
 					throw (OutOfMemoryError)xmlData.parseError;
 				} else {
 					// TODO: Code quality: Use a class which can consume the causing exception.
+					// Also applies to further usages of this class in this function.
 					throw new ParseException(message, -1);
 				}
 			}
@@ -723,8 +724,9 @@ public final class XMLTransformer {
 										Logger.normal(this, "New identity received via trust list: " + identity);
 									} catch(MalformedURLException urlEx) {
 										// Logging the exception does NOT log the actual malformed URL so we do it manually.
-										Logger.warning(this, "Received malformed identity URL: " + trusteeURI, urlEx);
-										throw urlEx;
+										String message = "Received malformed identity URL: " + trusteeURI;
+										Logger.warning(this, message, urlEx);
+										throw new ParseException(message, -1);
 									} catch (InvalidParameterException ipEx) {
 										// This is likely impossible as currently the Identity
 										// constructor only throws this upon an invalid nickname,

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -449,9 +449,13 @@ public final class XMLTransformer {
 	public void importIdentity(FreenetURI identityURI, InputStream xmlInputStream)
 			throws OutOfMemoryError {
 		
+		final ImportIdentityStatistics stats = new ImportIdentityStatistics();
+		
 		try { // Catch import problems so we can mark the edition as parsing failed
 		// We first parse the XML without synchronization, then do the synchronized import into the WebOfTrust		
+		stats.mXMLParsingTime = new StopWatch();
 		final ParsedIdentityXML xmlData = parseIdentityXML(xmlInputStream);
+		stats.mXMLParsingTime.stop();
 		
 		synchronized(mWoT) {
 		synchronized(mWoT.getIdentityFetcher()) {

--- a/src/plugins/WebOfTrust/XMLTransformer.java
+++ b/src/plugins/WebOfTrust/XMLTransformer.java
@@ -842,6 +842,8 @@ public final class XMLTransformer {
 			synchronized(mWoT.getIdentityDownloaderController()) {
 			// synchronized(mSubscriptionManager) { // We don't use the SubscriptionManager, see below
 			synchronized(Persistent.transactionLock(mDB) ) {
+				StopWatch markAsParsingFailedTime = new StopWatch();
+				
 				// FIXME: build0020 lacked a try/catch block to rollback the transaction upon error
 				// even though the old version of this code block also did multiple modifications to
 				// the Identity object and thus the database could become inconsistent if something
@@ -903,6 +905,12 @@ public final class XMLTransformer {
 						"also failed! URI: " + identityURI, doubleFault);
 					Persistent.checkedRollback(mDB, this, doubleFault);
 				}
+				
+				markAsParsingFailedTime.stop();
+				if(stats.mImportTime == null)
+					stats.mImportTime = markAsParsingFailedTime;
+				else
+					stats.mImportTime.add(markAsParsingFailedTime);
 			}
 			}
 			}

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -22,7 +22,7 @@ import freenet.keys.FreenetURI;
 /**
  * Downloads {@link Identity} objects from the P2P network.
  * Strictly all of them are then fed as {@link IdentityFile} to the {@link IdentityFileQueue}, which
- * is consumed by the {@link IdentityFileProcessor}.
+ * the {@link IdentityFileProcessor} polls and feeds into the {@link XMLTransformer}.
  * 
  * Implementations must tolerate loss of the output {@link IdentityFileQueue} across restarts of
  * WoT as required by the JavaDoc of that interface!  

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -468,10 +468,14 @@ public interface IdentityDownloader extends Daemon {
 	 * To ensure already downloaded editions are not downloaded again in between onSuccess() and
 	 * onNewEditionImported() implementations should use
 	 * {@link IdentityFileQueue#containsAnyEditionOf(FreenetURI)} in their download scheduler to not
-	 * start a download for an Identity if that function returns true.   
+	 * start a download for an Identity if that function returns true and thereby indicates that
+	 * they've already downloaded an edition of that Identity.   
 	 * See the large documentation inside of {@link IdentityDownloaderSlow#onSuccess(
 	 * freenet.client.FetchResult, freenet.client.async.ClientGetter)} for why this whole design
 	 * pattern is a good idea.
+	 * As a side effect this design pattern also ensures collaboration among IdentityDownloaders:  
+	 * If one implementation downloads an edition, other implementations running in parallel may
+	 * avoid trying to download the same edition again.
 	 * 
 	 * Synchronization:
 	 * This function is guaranteed to be called while the following locks are being held in the

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -447,8 +447,8 @@ public interface IdentityDownloader extends Daemon {
 	void storeNewEditionHintCommandWithoutCommit(EditionHint hint);
 
 	/**
-	 * Called by the {@link XMLTransformer} after we've finished importing a new edition of an
-	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to it by an
+	 * Called by the {@link XMLTransformer} after it has imported a new edition of an
+	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to the queue by an
 	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
 	 * 

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -451,6 +451,8 @@ public interface IdentityDownloader extends Daemon {
 	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to the queue by an
 	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
+	 * FIXME: What about OwnIdentitys, should the IdentityInserter call it so we don't download
+	 * their editions after upload?
 	 * 
 	 * The {@link IdentityDownloader} interface JavaDoc requires IdentityDownloader implementations
 	 * as a whole to be safe against loss of the output {@link IdentityFileQueue} upon restarts of

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloader.java
@@ -448,8 +448,8 @@ public interface IdentityDownloader extends Daemon {
 
 	/**
 	 * Called by the {@link XMLTransformer} after we've finished importing a new edition of an
-	 * {@link Identity} (which has been downloaded by an IdentityDownloader implementation before
-	 * import).  
+	 * {@link Identity} from the {@link IdentityFileQueue} (which has been added to it by an
+	 * IdentityDownloader before).  
 	 * The edition can be obtained from {@link Identity#getLastFetchedEdition()}.
 	 * 
 	 * The {@link IdentityDownloader} interface JavaDoc requires IdentityDownloader implementations

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -908,7 +908,7 @@ public final class IdentityDownloaderSlow implements
 			// 
 			// Doing deleteEditionHintsAndCommit() here would break the convention of not relying on
 			// any disk storage to be reliable except the database in order to keep the database
-			// consistent = it would break the ACID properties of the database:
+			// consistent, which would break the ACID properties of the database:
 			// If the mOutputQueue would get its files deleted after the call (which not only the
 			// user or power loss could cause, but also normal operation of IdentityFileQueue
 			// implementations! - see its JavaDoc) then we wouldn't try downloading the the

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -938,13 +938,14 @@ public final class IdentityDownloaderSlow implements
 			//    It also wouldn't work with IdentityFileMemoryQueue.
 			//    Further fsync is an expensive operation as it prevents write caching.
 			// 2. Don't do the deleteEditionHintsAndCommit() here but when actually importing the
-			//    IdentityFile from the IdentityFileQueue. This can be done by adding a new callback
-			//    onNewEditionImported() to IdentityDownloader which is called by WoT upon import
-			//    and whose implementation in this class then looks at the new value of
-			//    Identity.getLastFetchedEdition() to call deleteEditionHints() accordingly (make
-			//    sure to add and use a special version of it which it doesn't commit(), the
-			//    callback will likely be part of a transaction which is started by
-			//    IdentityFileProcessor and ought to be committed by it!).
+			//    IdentityFile from the IdentityFileQueue mOutputQueue - which is the fix I've
+			//    decided to use via the new onNewEditionImported() callback of our interface
+			//    IdentityDownloader.
+			//    It is called by WoT upon import of the IdentityFile from the queue and its
+			//    implementation in this class then looks at the new value of
+			//    Identity.getLastFetchedEdition() to call deleteEditionHints() accordingly (it
+			//    uses the non-*AndCommit() version because the callback is part of a transaction
+			//    which is started by IdentityFileProcessor and ought to be committed by it).
 			//    To prevent the mDownloadSchedulerThread from starting a download for the same
 			//    edition again while it is still queued for processing you must add code to it
 			//    which before starting a download checks the mOutputQueue for whether the edition

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -694,6 +694,8 @@ public final class IdentityDownloaderSlow implements
 					// doing excessive I/O:
 					// Then we're querying very many hints from the database for getting little
 					// useful ones.
+					// This issue is what we're trying to limit by obeying
+					// mOutputQueue.getSizeSoftLimit() at the beginning of the function.
 					Logger.minor(this, "run(): Ignored hints: " + ignoredHints);
 					
 					Logger.minor(this,

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -925,7 +925,7 @@ public final class IdentityDownloaderSlow implements
 			// would lose **all** of its contents upon power loss.
 			// 
 			// There are two potential fixes:
-			// 1. Ensure the IdentityFileDiskQueue does fsync before returning from the above add().
+			// 1. Ensure the above mOutputQueue.add() does fsync before returning.
 			//    This doesn't fix the backup code though and is still not 100% theoretically
 			//    precise because it doesn't take account for other types of transactional
 			//    decoherence between the database and the IdentityFileQueue besides the already

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -961,12 +961,17 @@ public final class IdentityDownloaderSlow implements
 			// Closing the stream deletes the IdentityFile on disk, which would cause the upcoming
 			// IdentityFileDiskQueue.contains() to return false - which in turn would cause the XML
 			// to be downloaded by the IdentityDownloaderSlow again while the import is running.
+			//
+			// FIXME: This is now fully handled by onNewEditionImported(), so the above FIXME
+			// can now be recycled into documentation as requested.
+			/*
 			int deletedHints = deleteEditionHintsAndCommit(uri, true, null);
 			if(deletedHints > 1) {
 				synchronized(mLock) {
 					mSkippedDownloads += deletedHints - 1;
 				}
 			}
+			*/
 		} catch (IOException | Error | RuntimeException e) {
 			Logger.error(this, "onSuccess(): Failed for URI: " + uri, e);
 		} finally {
@@ -993,6 +998,9 @@ public final class IdentityDownloaderSlow implements
 		int deletedHints = deleteEditionHints(uri, true, null);
 		assert(deletedHints > 0
 		    || deletedHints == 0 /* A different IdentityDownloader downloaded it. */);
+		
+		if(deletedHints > 1)
+			mSkippedDownloads += deletedHints - 1;
 		
 		// We don't have to try to cancel a potentially running download because that happens in
 		// onSuccess() right after the downloads finish, and the download scheduler must not start

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -947,13 +947,9 @@ public final class IdentityDownloaderSlow implements
 			//    uses the non-*AndCommit() version because the callback is part of a transaction
 			//    which is started by XMLTransformer and ought to be committed by it).
 			//    To prevent the mDownloadSchedulerThread from starting a download for the same
-			//    edition again while it is still queued for processing you must add code to it
-			//    which before starting a download checks the mOutputQueue for whether the edition
-			//    (or a higher one!) is queue there already. (Alternatively the delay for which
-			//    IdentityFileProcessor waits after mOutputQueue.add() before processing the queue
-			//    could be made sufficiently smaller as compared to the delay of the below
-			//    mDownloadSchedulerThread.triggerExecution() but in practice that race condition
-			//    could very often result in duplicate downloads.)
+			//    edition again while it is still queued for processing code was added to it which
+			//    before starting a download checks the mOutputQueue for whether an edition of
+			//    the particular Identity is queued there already.
 			//    Further advantages beyond ACID of this approach would be:
 			//    - it will also allow the IdentityDownloaderFast to notice when the
 			//      IdentityDownloaderSlow has found a new edition, which is a pending FIXME of this

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -553,7 +553,8 @@ public final class IdentityDownloaderSlow implements
 		// complete after the queue is full already.
 		if(mOutputQueue.getSize() > mOutputQueue.getSizeSoftLimit()) {
 			if(logMINOR) {
-				Logger.minor(this, "mOutputQueue too full, not starting new downloads, getSize(): "
+				Logger.minor(this,
+					"run(): mOutputQueue too full, not starting new downloads, getSize(): "
 					+ mOutputQueue.getSize());
 			}
 			// FIXME: Use an intelligent delay instead of a fixed one, e.g.:
@@ -680,7 +681,7 @@ public final class IdentityDownloaderSlow implements
 						if(--downloadsToSchedule <= 0)
 							break;
 					} catch(FetchException e) {
-						Logger.error(this, "FetchException for: " + h, e);
+						Logger.error(this, "run(): FetchException for: " + h, e);
 					}
 					
 					if(currentThread().isInterrupted()) {

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -545,20 +545,21 @@ public final class IdentityDownloaderSlow implements
 		//
 		// Notice: This is intentionally done *outside* of the below synchronized() blocks even
 		// though the size of the queue may be different until we acquire the locks. That is
-		// necessary because mOutputQueue.getSizeSoftLimit() takes the lock of the queue and for
-		// that WoT currently has no locking order convention (to avoid deadlocks) in relation to
-		// the locks taken below.
+		// necessary because mOutputQueue.getSize() takes the lock of the queue and for that WoT
+		// currently has no locking order convention (to avoid deadlocks) in relation to the locks
+		// taken below.
 		// The queue potentially growing meanwhile is not an issue because the "Soft" part of the
-		// queue size limit is to allow some leeway for running downloads.
+		// queue size limit is to allow some leeway for already running downloads which may
+		// complete after the queue is full already.
 		if(mOutputQueue.getSize() > mOutputQueue.getSizeSoftLimit()) {
 			if(logMINOR) {
 				Logger.minor(this, "mOutputQueue too full, not starting new downloads, getSize(): "
 					+ mOutputQueue.getSize());
 			}
-			// FIXME: Use a more intelligent delay, e.g.:
+			// FIXME: Use an intelligent delay instead of a fixed one, e.g.:
 			// - IdentityFileProcessor computes the average time it takes to process a file.
-			//   Divide the queue size by that to get the time until it will be empty, and use that
-			//   as delay.
+			//   Multiply the queue size by that to get the time until it will be empty, and use
+			//   that as delay.
 			// - Refine the above by computing the time until only a small amount of files is left
 			//   in the queue and use that as delay. Once the delay is over, and we run here and
 			//   see that the queue size is that small, sleep for only 1 second, check if it is

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -847,6 +847,8 @@ public final class IdentityDownloaderSlow implements
 			// because the files aren't available for import anymore. This also causes
 			// WebOfTrust.db4o to not be self-contained anymore, our defrag code and users would
 			// also have to copy the queue directory for backup purposes.
+			// EDIT: Actually the IdentityFileDiskQueue even by design deletes files in its
+			// temporary directory mProcessingDir after WoT has been restarted!
 			// There are two potential fixes:
 			// 1. Ensure the IdentityFileDiskQueue does fsync before returning from the above add().
 			//    This doesn't fix the backup code though and is still not 100% theoretically

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -945,7 +945,7 @@ public final class IdentityDownloaderSlow implements
 			//    implementation in this class then looks at the new value of
 			//    Identity.getLastFetchedEdition() to call deleteEditionHints() accordingly (it
 			//    uses the non-*AndCommit() version because the callback is part of a transaction
-			//    which is started by IdentityFileProcessor and ought to be committed by it).
+			//    which is started by XMLTransformer and ought to be committed by it).
 			//    To prevent the mDownloadSchedulerThread from starting a download for the same
 			//    edition again while it is still queued for processing you must add code to it
 			//    which before starting a download checks the mOutputQueue for whether the edition

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -919,6 +919,10 @@ public final class IdentityDownloaderSlow implements
 			// Copying a whole directory hierachy instead of just a database file is a non-trivial
 			// operation which can also be interrupted at an arbitrary incompleteness so then
 			// validating if a backup is valid would also be more complex.
+			// And then we still haven't even dealt with the implications of perhaps someday
+			// IdentityFileDiskQueue being replaced with IdentityFileMemoryQueue for some users
+			// (e.g. those without a SSD or with a cheap SSD which mustn't be written to much) - it
+			// would lose **all** of its contents upon power loss.
 			// 
 			// There are two potential fixes:
 			// 1. Ensure the IdentityFileDiskQueue does fsync before returning from the above add().

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -290,6 +290,7 @@ public final class IdentityDownloaderSlow implements
 
 	private int mSucceededDownloads = 0;
 
+	/** @see IdentityDownloaderSlowStatistics#mSkippedDownloads */
 	private int mSkippedDownloads = 0;
 
 	private int mFailedTemporarilyDownloads = 0;
@@ -1851,7 +1852,11 @@ public final class IdentityDownloaderSlow implements
 		 * order (see {@link EditionHint#compareTo(EditionHint)}) to hopefully download the latest
 		 * editions first so we don't need to try to download many old editions. Once we download an
 		 * edition of an Identity which is newer than some pending queued hints they will be
-		 * deleted. Deleting each thus spares us a single download which is nice. */
+		 * deleted. Deleting each thus spares us a single download which is nice.
+		 * 
+		 * Notice that this value may be inaccurate if a database transaction which called
+		 * {@link IdentityDownloaderSlow#onNewEditionImported(Identity)} is rolled back due to
+		 * errors. */
 		public final int mSkippedDownloads;
 
 		/** E.g. lack of network connection */

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -558,7 +558,8 @@ public final class IdentityDownloaderSlow implements
 					+ mOutputQueue.getSize());
 			}
 			// FIXME: Use an intelligent delay instead of a fixed one, e.g.:
-			// - IdentityFileProcessor computes the average time it takes to process a file.
+			// - IdentityFileProcessor computes the average time it takes to process a file, see
+			//   IdentityFileProcessor.Statistics.getAverageXMLImportTime().
 			//   Multiply the queue size by that to get the time until it will be empty, and use
 			//   that as delay.
 			// - Refine the above by computing the time until only a small amount of files is left

--- a/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
+++ b/src/plugins/WebOfTrust/network/input/IdentityDownloaderSlow.java
@@ -917,8 +917,8 @@ public final class IdentityDownloaderSlow implements
 			// cause our backup and defrag code and users to also have to copy the queue directory
 			// for backup purposes, not just the database.
 			// Copying a whole directory hierachy instead of just a database file is a non-trivial
-			// operation which can also be interrupted so then validating if a backup is valid would
-			// also be more complex.
+			// operation which can also be interrupted at an arbitrary incompleteness so then
+			// validating if a backup is valid would also be more complex.
 			// 
 			// There are two potential fixes:
 			// 1. Ensure the IdentityFileDiskQueue does fsync before returning from the above add().

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -38,6 +38,7 @@ public final class StopWatch {
 	}
 
 	public void divideNanosBy(long divisor) {
+		stopIfNotStoppedYet();
 		mStopTime = mStartTime + (mStopTime - mStartTime) / divisor;
 	}
 

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -3,9 +3,8 @@
  * any later version). See http://www.gnu.org/ for details of the GPL. */
 package plugins.WebOfTrust.util;
 
-import java.util.concurrent.TimeUnit;
-
-import freenet.support.TimeUtil;
+import static freenet.support.TimeUtil.formatTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /** Utility class for measuring execution time of code. */
 public final class StopWatch {
@@ -43,7 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(getNanos()), 3, true);
+		return formatTime(NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
 }

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -45,4 +45,9 @@ public final class StopWatch {
 		return formatTime(NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
+	public void add(StopWatch other) {
+		stopIfNotStoppedYet();
+		mStopTime += other.getNanos();
+	}
+
 }

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -23,6 +23,11 @@ public final class StopWatch {
 		mStopTime = System.nanoTime();
 	}
 
+	public void stopIfNotStoppedYet() {
+		if(!wasStopped())
+			stop();
+	}
+
 	public boolean wasStopped() {
 		return mStopTime != null;
 	}

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -23,6 +23,10 @@ public final class StopWatch {
 		mStopTime = System.nanoTime();
 	}
 
+	public boolean wasStopped() {
+		return mStopTime != null;
+	}
+
 	public long getNanos() {
 		if(mStopTime == null)
 			stop();

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -33,9 +33,7 @@ public final class StopWatch {
 	}
 
 	public long getNanos() {
-		if(mStopTime == null)
-			stop();
-		
+		stopIfNotStoppedYet();
 		return mStopTime - mStartTime;
 	}
 
@@ -44,9 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		if(mStopTime == null)
-			stop();
-		
+		stopIfNotStoppedYet();
 		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(mStopTime - mStartTime), 3, true);
 	}
 

--- a/src/plugins/WebOfTrust/util/StopWatch.java
+++ b/src/plugins/WebOfTrust/util/StopWatch.java
@@ -42,8 +42,7 @@ public final class StopWatch {
 	}
 
 	public String toString() {
-		stopIfNotStoppedYet();
-		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(mStopTime - mStartTime), 3, true);
+		return TimeUtil.formatTime(TimeUnit.NANOSECONDS.toMillis(getNanos()), 3, true);
 	}
 
 }


### PR DESCRIPTION
_Please merge with `--ff-only` into `issue-0003816-IdentityFetcher-rewrite`._
_This also contains the commits of the previous PRs to that branch._
